### PR TITLE
Implement data types, type hierarchy, and internal TypeVars

### DIFF
--- a/src/colnade/__init__.py
+++ b/src/colnade/__init__.py
@@ -1,1 +1,61 @@
 """Colnade: A statically type-safe DataFrame abstraction layer."""
+
+from colnade.dtypes import (
+    Binary,
+    Bool,
+    Date,
+    Datetime,
+    Duration,
+    Float32,
+    Float64,
+    FloatType,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    IntegerType,
+    List,
+    NumericType,
+    Struct,
+    TemporalType,
+    Time,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Utf8,
+)
+
+__all__ = [
+    # Type categories
+    "NumericType",
+    "IntegerType",
+    "FloatType",
+    "TemporalType",
+    # Boolean
+    "Bool",
+    # Unsigned integers
+    "UInt8",
+    "UInt16",
+    "UInt32",
+    "UInt64",
+    # Signed integers
+    "Int8",
+    "Int16",
+    "Int32",
+    "Int64",
+    # Floating point
+    "Float32",
+    "Float64",
+    # String / binary
+    "Utf8",
+    "Binary",
+    # Temporal
+    "Date",
+    "Time",
+    "Datetime",
+    "Duration",
+    # Parameterized nested types
+    "Struct",
+    "List",
+]

--- a/src/colnade/_types.py
+++ b/src/colnade/_types.py
@@ -1,1 +1,23 @@
-"""Internal typing utilities."""
+"""Internal typing utilities for Colnade.
+
+Core TypeVars used across the library. Schema-bound TypeVars (S, S2, S3,
+SchemaType) are defined in schema.py once Schema exists.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from colnade.dtypes import FloatType, NumericType
+
+# General-purpose type variable for column data types
+DType = TypeVar("DType")
+
+# Element type (used in List[T] and other generic contexts)
+T = TypeVar("T")
+
+# Numeric type variable (for constraining methods like .sum(), .mean())
+N = TypeVar("N", bound=NumericType)
+
+# Float type variable (for constraining NaN methods like .is_nan(), .fill_nan())
+F = TypeVar("F", bound=FloatType)

--- a/src/colnade/dtypes.py
+++ b/src/colnade/dtypes.py
@@ -1,1 +1,166 @@
-"""Data type definitions."""
+"""Data type definitions for Colnade.
+
+All column types are sentinel classes — they don't hold data. They exist so that
+Column[UInt8, S] is a meaningful generic type and the type checker can distinguish
+column types and enforce method availability by dtype.
+
+Type categories (NumericType, FloatType, TemporalType) are base classes, enabling
+TypeVar bounds for method constraints (e.g., .sum() only on NumericType columns).
+"""
+
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+# ---------------------------------------------------------------------------
+# Type category base classes
+# ---------------------------------------------------------------------------
+
+
+class NumericType:
+    """Base class for all numeric data types."""
+
+
+class IntegerType(NumericType):
+    """Base class for all integer data types (signed and unsigned)."""
+
+
+class FloatType(NumericType):
+    """Base class for floating-point data types. Used to constrain NaN methods."""
+
+
+class TemporalType:
+    """Base class for all temporal data types."""
+
+
+# ---------------------------------------------------------------------------
+# Boolean
+# ---------------------------------------------------------------------------
+
+
+class Bool:
+    """Boolean type. Not numeric — arithmetic on booleans is not supported."""
+
+
+# ---------------------------------------------------------------------------
+# Unsigned integers
+# ---------------------------------------------------------------------------
+
+
+class UInt8(IntegerType):
+    """8-bit unsigned integer."""
+
+
+class UInt16(IntegerType):
+    """16-bit unsigned integer."""
+
+
+class UInt32(IntegerType):
+    """32-bit unsigned integer."""
+
+
+class UInt64(IntegerType):
+    """64-bit unsigned integer."""
+
+
+# ---------------------------------------------------------------------------
+# Signed integers
+# ---------------------------------------------------------------------------
+
+
+class Int8(IntegerType):
+    """8-bit signed integer."""
+
+
+class Int16(IntegerType):
+    """16-bit signed integer."""
+
+
+class Int32(IntegerType):
+    """32-bit signed integer."""
+
+
+class Int64(IntegerType):
+    """64-bit signed integer."""
+
+
+# ---------------------------------------------------------------------------
+# Floating point
+# ---------------------------------------------------------------------------
+
+
+class Float32(FloatType):
+    """32-bit floating point."""
+
+
+class Float64(FloatType):
+    """64-bit floating point."""
+
+
+# ---------------------------------------------------------------------------
+# String / Binary
+# ---------------------------------------------------------------------------
+
+
+class Utf8:
+    """UTF-8 encoded string."""
+
+
+class Binary:
+    """Raw binary data."""
+
+
+# ---------------------------------------------------------------------------
+# Temporal
+# ---------------------------------------------------------------------------
+
+
+class Date(TemporalType):
+    """Calendar date (no time component)."""
+
+
+class Time(TemporalType):
+    """Time of day (no date component)."""
+
+
+class Datetime(TemporalType):
+    """Date and time."""
+
+
+class Duration(TemporalType):
+    """Time duration / interval."""
+
+
+# ---------------------------------------------------------------------------
+# Parameterized nested types
+# ---------------------------------------------------------------------------
+
+_S = TypeVar("_S")
+_T = TypeVar("_T")
+
+
+class Struct(Generic[_S]):
+    """A struct column type parameterized by a Schema class.
+
+    Usage in schema definitions::
+
+        class Address(Schema):
+            street: Utf8
+            city: Utf8
+
+        class Users(Schema):
+            address: Struct[Address]
+            location: Struct[GeoPoint] | None  # nullable struct
+    """
+
+
+class List(Generic[_T]):
+    """A list column type parameterized by element type.
+
+    Usage in schema definitions::
+
+        class Users(Schema):
+            tags: List[Utf8]                  # list of strings
+            scores: List[Float64 | None]      # list of nullable floats
+            friends: List[UInt64] | None      # nullable list
+    """

--- a/tests/typing/test_dtypes.py
+++ b/tests/typing/test_dtypes.py
@@ -1,0 +1,110 @@
+"""Static type tests for colnade.dtypes.
+
+This file is checked by ty — it must produce zero type errors.
+It verifies that the type hierarchy is visible to the type checker
+and that generic parameterization works correctly.
+"""
+
+from colnade._types import DType, F, N, T
+from colnade.dtypes import (
+    Binary,
+    Bool,
+    Date,
+    Datetime,
+    Duration,
+    Float32,
+    Float64,
+    FloatType,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    IntegerType,
+    List,
+    NumericType,
+    Struct,
+    TemporalType,
+    Time,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Utf8,
+)
+
+# --- Type category hierarchy visible to type checker ---
+
+
+def check_integer_is_numeric(x: IntegerType) -> NumericType:
+    return x
+
+
+def check_float_is_numeric(x: FloatType) -> NumericType:
+    return x
+
+
+def check_uint8_is_integer(x: UInt8) -> IntegerType:
+    return x
+
+
+def check_int64_is_integer(x: Int64) -> IntegerType:
+    return x
+
+
+def check_float64_is_float(x: Float64) -> FloatType:
+    return x
+
+
+def check_date_is_temporal(x: Date) -> TemporalType:
+    return x
+
+
+def check_datetime_is_temporal(x: Datetime) -> TemporalType:
+    return x
+
+
+def check_duration_is_temporal(x: Duration) -> TemporalType:
+    return x
+
+
+def check_time_is_temporal(x: Time) -> TemporalType:
+    return x
+
+
+# --- Generic parameterized types ---
+
+_struct_alias: type[Struct[int]] = Struct
+_list_alias: type[List[str]] = List
+
+
+# --- All sentinel classes exist and are usable as types ---
+
+
+def check_all_types_exist() -> None:
+    _: type[Bool] = Bool
+    _: type[UInt8] = UInt8
+    _: type[UInt16] = UInt16
+    _: type[UInt32] = UInt32
+    _: type[UInt64] = UInt64
+    _: type[Int8] = Int8
+    _: type[Int16] = Int16
+    _: type[Int32] = Int32
+    _: type[Int64] = Int64
+    _: type[Float32] = Float32
+    _: type[Float64] = Float64
+    _: type[Utf8] = Utf8
+    _: type[Binary] = Binary
+    _: type[Date] = Date
+    _: type[Time] = Time
+    _: type[Datetime] = Datetime
+    _: type[Duration] = Duration
+
+
+# --- TypeVars are importable ---
+
+
+def check_typevars_exist() -> None:
+    _ = DType
+    _ = T
+    _ = N
+    _ = F

--- a/tests/unit/test_dtypes.py
+++ b/tests/unit/test_dtypes.py
@@ -1,0 +1,222 @@
+"""Unit tests for colnade.dtypes and colnade._types."""
+
+from colnade.dtypes import (
+    Binary,
+    Bool,
+    Date,
+    Datetime,
+    Duration,
+    Float32,
+    Float64,
+    FloatType,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    IntegerType,
+    List,
+    NumericType,
+    Struct,
+    TemporalType,
+    Time,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Utf8,
+)
+
+# ---------------------------------------------------------------------------
+# Type category hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestTypeHierarchy:
+    """Verify the inheritance relationships between dtype categories."""
+
+    def test_integer_types_are_numeric(self) -> None:
+        for cls in (UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64):
+            assert issubclass(cls, NumericType), f"{cls.__name__} should be NumericType"
+            assert issubclass(cls, IntegerType), f"{cls.__name__} should be IntegerType"
+
+    def test_float_types_are_numeric(self) -> None:
+        for cls in (Float32, Float64):
+            assert issubclass(cls, NumericType), f"{cls.__name__} should be NumericType"
+            assert issubclass(cls, FloatType), f"{cls.__name__} should be FloatType"
+
+    def test_float_types_are_not_integer(self) -> None:
+        for cls in (Float32, Float64):
+            assert not issubclass(cls, IntegerType), f"{cls.__name__} should not be IntegerType"
+
+    def test_integer_types_are_not_float(self) -> None:
+        for cls in (UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64):
+            assert not issubclass(cls, FloatType), f"{cls.__name__} should not be FloatType"
+
+    def test_temporal_types(self) -> None:
+        for cls in (Date, Time, Datetime, Duration):
+            assert issubclass(cls, TemporalType), f"{cls.__name__} should be TemporalType"
+            assert not issubclass(cls, NumericType), f"{cls.__name__} should not be NumericType"
+
+    def test_bool_is_standalone(self) -> None:
+        assert not issubclass(Bool, NumericType)
+        assert not issubclass(Bool, TemporalType)
+
+    def test_utf8_is_standalone(self) -> None:
+        assert not issubclass(Utf8, NumericType)
+        assert not issubclass(Utf8, TemporalType)
+
+    def test_binary_is_standalone(self) -> None:
+        assert not issubclass(Binary, NumericType)
+        assert not issubclass(Binary, TemporalType)
+
+
+# ---------------------------------------------------------------------------
+# Sentinel classes are instantiable (needed for runtime introspection)
+# ---------------------------------------------------------------------------
+
+
+class TestSentinelInstantiation:
+    """Sentinel dtype classes should be simple instantiable classes."""
+
+    def test_all_dtypes_instantiable(self) -> None:
+        all_dtypes = [
+            Bool,
+            UInt8,
+            UInt16,
+            UInt32,
+            UInt64,
+            Int8,
+            Int16,
+            Int32,
+            Int64,
+            Float32,
+            Float64,
+            Utf8,
+            Binary,
+            Date,
+            Time,
+            Datetime,
+            Duration,
+        ]
+        for cls in all_dtypes:
+            instance = cls()
+            assert isinstance(instance, cls)
+
+
+# ---------------------------------------------------------------------------
+# Parameterized nested types
+# ---------------------------------------------------------------------------
+
+
+class TestParameterizedTypes:
+    """Struct and List are Generic types usable as type parameters."""
+
+    def test_struct_is_generic(self) -> None:
+        # Struct[X] should be subscriptable at runtime
+        alias = Struct[int]
+        assert alias is not None
+
+    def test_list_is_generic(self) -> None:
+        # List[X] should be subscriptable at runtime
+        alias = List[int]
+        assert alias is not None
+
+
+# ---------------------------------------------------------------------------
+# Public API re-exports
+# ---------------------------------------------------------------------------
+
+
+class TestPublicAPI:
+    """Verify __init__.py re-exports all expected names."""
+
+    def test_all_types_in_colnade_namespace(self) -> None:
+        import colnade
+
+        expected = [
+            "NumericType",
+            "IntegerType",
+            "FloatType",
+            "TemporalType",
+            "Bool",
+            "UInt8",
+            "UInt16",
+            "UInt32",
+            "UInt64",
+            "Int8",
+            "Int16",
+            "Int32",
+            "Int64",
+            "Float32",
+            "Float64",
+            "Utf8",
+            "Binary",
+            "Date",
+            "Time",
+            "Datetime",
+            "Duration",
+            "Struct",
+            "List",
+        ]
+        for name in expected:
+            assert hasattr(colnade, name), f"colnade.{name} should be exported"
+
+    def test_all_list_complete(self) -> None:
+        import colnade
+
+        # __all__ should contain every expected public name
+        expected = {
+            "NumericType",
+            "IntegerType",
+            "FloatType",
+            "TemporalType",
+            "Bool",
+            "UInt8",
+            "UInt16",
+            "UInt32",
+            "UInt64",
+            "Int8",
+            "Int16",
+            "Int32",
+            "Int64",
+            "Float32",
+            "Float64",
+            "Utf8",
+            "Binary",
+            "Date",
+            "Time",
+            "Datetime",
+            "Duration",
+            "Struct",
+            "List",
+        }
+        assert expected == set(colnade.__all__)
+
+
+# ---------------------------------------------------------------------------
+# TypeVars (basic sanity — they're just TypeVar objects)
+# ---------------------------------------------------------------------------
+
+
+class TestTypeVars:
+    """Verify TypeVars exist and have correct bounds."""
+
+    def test_dtype_typevar(self) -> None:
+        from colnade._types import DType
+
+        assert DType.__name__ == "DType"
+
+    def test_numeric_typevar_bound(self) -> None:
+        from colnade._types import N
+
+        assert N.__bound__ is NumericType
+
+    def test_float_typevar_bound(self) -> None:
+        from colnade._types import F
+
+        assert F.__bound__ is FloatType
+
+    def test_element_typevar(self) -> None:
+        from colnade._types import T
+
+        assert T.__name__ == "T"


### PR DESCRIPTION
## Summary
- Implements all sentinel dtype classes with a class-based type hierarchy (NumericType → IntegerType/FloatType, TemporalType, standalone Bool/Utf8/Binary)
- Adds generic parameterized nested types: `Struct[S]` and `List[T]`
- Defines core TypeVars in `_types.py`: `DType`, `T`, `N` (bound=NumericType), `F` (bound=FloatType)
- Re-exports all public types from `colnade.__init__` with complete `__all__`

## Design decisions
- **Class hierarchy over Union aliases**: Type categories (NumericType, IntegerType, FloatType, TemporalType) are base classes rather than Union type aliases. This enables clean `TypeVar("N", bound=NumericType)` bounds for method constraints (e.g., `.sum()` only on numeric columns), which is more ergonomic than Union-based approaches.
- **FloatType as separate intermediate class**: Distinguishes float-specific methods (`.is_nan()`, `.fill_nan()`) from general numeric methods via `TypeVar("F", bound=FloatType)`.
- **Schema-bound TypeVars deferred**: TypeVars that need `bound=Schema` (S, S2, S3, SchemaType) will be defined in `schema.py` in issue #3, since TypeVar doesn't support string forward references for bounds.

## Files changed
| File | Change |
|------|--------|
| `src/colnade/dtypes.py` | All dtype sentinel classes + type category base classes + Struct/List generics |
| `src/colnade/_types.py` | Core TypeVars (DType, T, N, F) |
| `src/colnade/__init__.py` | Re-exports all public types with `__all__` |
| `tests/unit/test_dtypes.py` | 17 unit tests: hierarchy, instantiation, API completeness, TypeVar bounds |
| `tests/typing/test_dtypes.py` | Static type tests verified by ty |

## Test plan
- [x] Unit tests verify type hierarchy inheritance (integer→numeric, float→numeric, temporal, standalone types)
- [x] Unit tests verify all sentinel classes are instantiable
- [x] Unit tests verify `__all__` completeness and namespace exports
- [x] Unit tests verify TypeVar bounds (N→NumericType, F→FloatType)
- [x] Static type tests pass ty check (hierarchy visibility, generic parameterization)
- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run pytest tests/ -v` — 19 tests pass
- [x] `uv run ty check tests/typing/` passes

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)