### PR TITLE
Implement DataFrame & LazyFrame interfaces (#6)

### DIFF
--- a/src/colnade/__init__.py
+++ b/src/colnade/__init__.py
@@ -1,5 +1,13 @@
 """Colnade: A statically type-safe DataFrame abstraction layer."""
 
+from colnade.dataframe import (
+    DataFrame,
+    GroupBy,
+    LazyFrame,
+    LazyGroupBy,
+    UntypedDataFrame,
+    UntypedLazyFrame,
+)
 from colnade.dtypes import (
     Binary,
     Bool,
@@ -46,6 +54,13 @@ __all__ = [
     "Schema",
     "Column",
     "ListAccessor",
+    # DataFrame layer
+    "DataFrame",
+    "LazyFrame",
+    "GroupBy",
+    "LazyGroupBy",
+    "UntypedDataFrame",
+    "UntypedLazyFrame",
     # Expression DSL
     "Expr",
     "ColumnRef",

--- a/src/colnade/dataframe.py
+++ b/src/colnade/dataframe.py
@@ -1,1 +1,389 @@
-"""DataFrame[S], LazyFrame[S], JoinedDataFrame[S, S2], etc."""
+"""DataFrame[S], LazyFrame[S], GroupBy, and untyped escape hatches.
+
+Typed DataFrame interfaces parameterized by Schema. At this stage these are
+interface definitions with stub method bodies — actual backend execution is
+delegated to a backend adapter (wired in Issue #9).
+
+Limitation: Column[DType] has a single type parameter (no schema binding),
+so methods like select(), sort(), group_by() accept Column[Any] and cannot
+statically enforce that columns belong to the DataFrame's schema S. Schema
+enforcement at the column level requires a second type parameter on Column,
+which was dropped due to Python 3.10 lacking TypeVar defaults (PEP 696).
+See AGENTS.md "Column[DType] Annotation Pattern" for details.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generic, overload
+
+from colnade.schema import Column, S
+
+if TYPE_CHECKING:
+    from colnade.dtypes import Bool
+    from colnade.expr import AliasedExpr, Expr, SortExpr
+
+
+# ---------------------------------------------------------------------------
+# DataFrame[S] — typed, materialized DataFrame
+# ---------------------------------------------------------------------------
+
+
+class DataFrame(Generic[S]):
+    """A typed, materialized DataFrame parameterized by a Schema.
+
+    Schema-preserving operations (filter, sort, limit, etc.) return
+    ``DataFrame[S]``. Schema-transforming operations (select, group_by+agg)
+    return ``DataFrame[Any]`` and require ``cast_schema()`` to bind to a
+    named output schema.
+    """
+
+    __slots__ = ("_data", "_schema")
+
+    def __init__(self, *, _data: Any = None, _schema: type[Any] | None = None) -> None:
+        self._data = _data
+        self._schema = _schema
+
+    def __repr__(self) -> str:
+        schema_name = self._schema.__name__ if self._schema else "Any"
+        return f"DataFrame[{schema_name}]"
+
+    # --- Schema-preserving operations (return DataFrame[S]) ---
+
+    def filter(self, predicate: Expr[Bool]) -> DataFrame[S]:
+        """Filter rows by a boolean expression."""
+        return DataFrame(_data=self._data, _schema=self._schema)
+
+    def sort(self, *columns: Column[Any] | SortExpr, descending: bool = False) -> DataFrame[S]:
+        """Sort rows by columns or sort expressions."""
+        return DataFrame(_data=self._data, _schema=self._schema)
+
+    def limit(self, n: int) -> DataFrame[S]:
+        """Limit to the first n rows."""
+        return DataFrame(_data=self._data, _schema=self._schema)
+
+    def head(self, n: int = 5) -> DataFrame[S]:
+        """Return the first n rows (materialized only)."""
+        return DataFrame(_data=self._data, _schema=self._schema)
+
+    def tail(self, n: int = 5) -> DataFrame[S]:
+        """Return the last n rows (materialized only)."""
+        return DataFrame(_data=self._data, _schema=self._schema)
+
+    def sample(self, n: int) -> DataFrame[S]:
+        """Return a random sample of n rows (materialized only)."""
+        return DataFrame(_data=self._data, _schema=self._schema)
+
+    def unique(self, *columns: Column[Any]) -> DataFrame[S]:
+        """Remove duplicate rows based on the given columns."""
+        return DataFrame(_data=self._data, _schema=self._schema)
+
+    def drop_nulls(self, *columns: Column[Any]) -> DataFrame[S]:
+        """Drop rows with null values in the given columns."""
+        return DataFrame(_data=self._data, _schema=self._schema)
+
+    def with_columns(self, *exprs: AliasedExpr[Any] | Expr[Any]) -> DataFrame[S]:
+        """Add or overwrite columns. Returns DataFrame[S] (optimistic).
+
+        Schema preservation is assumed — use ``cast_schema()`` to validate
+        and bind to a new schema if columns were added or changed types.
+        """
+        return DataFrame(_data=self._data, _schema=self._schema)
+
+    # --- Schema-transforming operations (return DataFrame[Any]) ---
+
+    @overload
+    def select(self, c1: Column[Any], /) -> DataFrame[Any]: ...
+    @overload
+    def select(self, c1: Column[Any], c2: Column[Any], /) -> DataFrame[Any]: ...
+    @overload
+    def select(self, c1: Column[Any], c2: Column[Any], c3: Column[Any], /) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self, c1: Column[Any], c2: Column[Any], c3: Column[Any], c4: Column[Any], /
+    ) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        /,
+    ) -> DataFrame[Any]: ...
+
+    def select(self, *columns: Column[Any]) -> DataFrame[Any]:
+        """Select columns. Returns DataFrame[Any] — use cast_schema() to bind."""
+        return DataFrame(_data=self._data, _schema=None)
+
+    # --- GroupBy ---
+
+    def group_by(self, *keys: Column[Any]) -> GroupBy[S]:
+        """Group by columns for aggregation."""
+        return GroupBy(_data=self._data, _schema=self._schema, _keys=keys)
+
+    # --- Conversion ---
+
+    def lazy(self) -> LazyFrame[S]:
+        """Convert to a lazy query plan."""
+        return LazyFrame(_data=self._data, _schema=self._schema)
+
+    def untyped(self) -> UntypedDataFrame:
+        """Drop type information — string-based escape hatch."""
+        return UntypedDataFrame(_data=self._data)
+
+    # --- Boundary stubs (deferred to later issues) ---
+
+    def validate(self) -> DataFrame[S]:
+        """Validate that the data conforms to the schema (Issue #8)."""
+        return self
+
+    def to_batches(self, batch_size: int | None = None) -> Any:
+        """Convert to Arrow batches (Issue #9)."""
+        raise NotImplementedError("to_batches requires a backend adapter (Issue #9)")
+
+
+# ---------------------------------------------------------------------------
+# LazyFrame[S] — typed, lazy query plan
+# ---------------------------------------------------------------------------
+
+
+class LazyFrame(Generic[S]):
+    """A typed, lazy query plan parameterized by a Schema.
+
+    Same operations as DataFrame except: no head(), tail(), sample(),
+    to_batches() (materialized-only ops). Use collect() to materialize.
+    """
+
+    __slots__ = ("_data", "_schema")
+
+    def __init__(self, *, _data: Any = None, _schema: type[Any] | None = None) -> None:
+        self._data = _data
+        self._schema = _schema
+
+    def __repr__(self) -> str:
+        schema_name = self._schema.__name__ if self._schema else "Any"
+        return f"LazyFrame[{schema_name}]"
+
+    # --- Schema-preserving operations (return LazyFrame[S]) ---
+
+    def filter(self, predicate: Expr[Bool]) -> LazyFrame[S]:
+        """Filter rows by a boolean expression."""
+        return LazyFrame(_data=self._data, _schema=self._schema)
+
+    def sort(self, *columns: Column[Any] | SortExpr, descending: bool = False) -> LazyFrame[S]:
+        """Sort rows by columns or sort expressions."""
+        return LazyFrame(_data=self._data, _schema=self._schema)
+
+    def limit(self, n: int) -> LazyFrame[S]:
+        """Limit to the first n rows."""
+        return LazyFrame(_data=self._data, _schema=self._schema)
+
+    def unique(self, *columns: Column[Any]) -> LazyFrame[S]:
+        """Remove duplicate rows based on the given columns."""
+        return LazyFrame(_data=self._data, _schema=self._schema)
+
+    def drop_nulls(self, *columns: Column[Any]) -> LazyFrame[S]:
+        """Drop rows with null values in the given columns."""
+        return LazyFrame(_data=self._data, _schema=self._schema)
+
+    def with_columns(self, *exprs: AliasedExpr[Any] | Expr[Any]) -> LazyFrame[S]:
+        """Add or overwrite columns. Returns LazyFrame[S] (optimistic)."""
+        return LazyFrame(_data=self._data, _schema=self._schema)
+
+    # --- Schema-transforming operations (return LazyFrame[Any]) ---
+
+    @overload
+    def select(self, c1: Column[Any], /) -> LazyFrame[Any]: ...
+    @overload
+    def select(self, c1: Column[Any], c2: Column[Any], /) -> LazyFrame[Any]: ...
+    @overload
+    def select(self, c1: Column[Any], c2: Column[Any], c3: Column[Any], /) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self, c1: Column[Any], c2: Column[Any], c3: Column[Any], c4: Column[Any], /
+    ) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        /,
+    ) -> LazyFrame[Any]: ...
+
+    def select(self, *columns: Column[Any]) -> LazyFrame[Any]:
+        """Select columns. Returns LazyFrame[Any] — use cast_schema() to bind."""
+        return LazyFrame(_data=self._data, _schema=None)
+
+    # --- GroupBy ---
+
+    def group_by(self, *keys: Column[Any]) -> LazyGroupBy[S]:
+        """Group by columns for aggregation."""
+        return LazyGroupBy(_data=self._data, _schema=self._schema, _keys=keys)
+
+    # --- Materialization ---
+
+    def collect(self) -> DataFrame[S]:
+        """Materialize the lazy query plan into a DataFrame."""
+        return DataFrame(_data=self._data, _schema=self._schema)
+
+    # --- Conversion ---
+
+    def untyped(self) -> UntypedLazyFrame:
+        """Drop type information — string-based escape hatch."""
+        return UntypedLazyFrame(_data=self._data)
+
+    # --- Boundary stubs ---
+
+    def validate(self) -> LazyFrame[S]:
+        """Validate that the data conforms to the schema (Issue #8)."""
+        return self
+
+
+# ---------------------------------------------------------------------------
+# GroupBy[S] and LazyGroupBy[S]
+# ---------------------------------------------------------------------------
+
+
+class GroupBy(Generic[S]):
+    """GroupBy on a materialized DataFrame.
+
+    Created by ``DataFrame.group_by()``. Use ``.agg()`` to produce
+    aggregated results (returns ``DataFrame[Any]`` requiring ``cast_schema``).
+    """
+
+    __slots__ = ("_data", "_schema", "_keys")
+
+    def __init__(
+        self,
+        *,
+        _data: Any = None,
+        _schema: type[Any] | None = None,
+        _keys: tuple[Column[Any], ...] = (),
+    ) -> None:
+        self._data = _data
+        self._schema = _schema
+        self._keys = _keys
+
+    def agg(self, *exprs: AliasedExpr[Any]) -> DataFrame[Any]:
+        """Aggregate grouped data. Returns DataFrame[Any] — use cast_schema()."""
+        return DataFrame(_data=self._data, _schema=None)
+
+
+class LazyGroupBy(Generic[S]):
+    """GroupBy on a lazy query plan.
+
+    Created by ``LazyFrame.group_by()``. Use ``.agg()`` to produce
+    aggregated results (returns ``LazyFrame[Any]`` requiring ``cast_schema``).
+    """
+
+    __slots__ = ("_data", "_schema", "_keys")
+
+    def __init__(
+        self,
+        *,
+        _data: Any = None,
+        _schema: type[Any] | None = None,
+        _keys: tuple[Column[Any], ...] = (),
+    ) -> None:
+        self._data = _data
+        self._schema = _schema
+        self._keys = _keys
+
+    def agg(self, *exprs: AliasedExpr[Any]) -> LazyFrame[Any]:
+        """Aggregate grouped data. Returns LazyFrame[Any] — use cast_schema()."""
+        return LazyFrame(_data=self._data, _schema=None)
+
+
+# ---------------------------------------------------------------------------
+# Untyped escape hatches
+# ---------------------------------------------------------------------------
+
+
+class UntypedDataFrame:
+    """A DataFrame with no schema parameter. String-based column access.
+
+    Created by ``DataFrame.untyped()``. Use ``to_typed()`` to re-enter
+    the typed world (performs runtime validation when backend is wired).
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self, *, _data: Any = None) -> None:
+        self._data = _data
+
+    def select(self, *columns: str) -> UntypedDataFrame:
+        """Select columns by name."""
+        return UntypedDataFrame(_data=self._data)
+
+    def filter(self, expr: Any) -> UntypedDataFrame:
+        """Filter rows."""
+        return UntypedDataFrame(_data=self._data)
+
+    def with_columns(self, *exprs: Any) -> UntypedDataFrame:
+        """Add or overwrite columns."""
+        return UntypedDataFrame(_data=self._data)
+
+    def sort(self, *columns: str, descending: bool = False) -> UntypedDataFrame:
+        """Sort rows by column names."""
+        return UntypedDataFrame(_data=self._data)
+
+    def limit(self, n: int) -> UntypedDataFrame:
+        """Limit to the first n rows."""
+        return UntypedDataFrame(_data=self._data)
+
+    def head(self, n: int = 5) -> UntypedDataFrame:
+        """Return the first n rows."""
+        return UntypedDataFrame(_data=self._data)
+
+    def tail(self, n: int = 5) -> UntypedDataFrame:
+        """Return the last n rows."""
+        return UntypedDataFrame(_data=self._data)
+
+    def to_typed(self, schema: type[S]) -> DataFrame[S]:
+        """Bind to a schema. Performs runtime validation (when backend is wired)."""
+        return DataFrame(_data=self._data, _schema=schema)
+
+
+class UntypedLazyFrame:
+    """A LazyFrame with no schema parameter. String-based column access.
+
+    Created by ``LazyFrame.untyped()``. Use ``to_typed()`` to re-enter
+    the typed world (performs runtime validation when backend is wired).
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self, *, _data: Any = None) -> None:
+        self._data = _data
+
+    def select(self, *columns: str) -> UntypedLazyFrame:
+        """Select columns by name."""
+        return UntypedLazyFrame(_data=self._data)
+
+    def filter(self, expr: Any) -> UntypedLazyFrame:
+        """Filter rows."""
+        return UntypedLazyFrame(_data=self._data)
+
+    def with_columns(self, *exprs: Any) -> UntypedLazyFrame:
+        """Add or overwrite columns."""
+        return UntypedLazyFrame(_data=self._data)
+
+    def sort(self, *columns: str, descending: bool = False) -> UntypedLazyFrame:
+        """Sort rows by column names."""
+        return UntypedLazyFrame(_data=self._data)
+
+    def limit(self, n: int) -> UntypedLazyFrame:
+        """Limit to the first n rows."""
+        return UntypedLazyFrame(_data=self._data)
+
+    def collect(self) -> UntypedDataFrame:
+        """Materialize the lazy query plan."""
+        return UntypedDataFrame(_data=self._data)
+
+    def to_typed(self, schema: type[S]) -> LazyFrame[S]:
+        """Bind to a schema. Performs runtime validation (when backend is wired)."""
+        return LazyFrame(_data=self._data, _schema=schema)

--- a/tests/typing/test_dataframe.py
+++ b/tests/typing/test_dataframe.py
@@ -1,0 +1,195 @@
+"""Static type tests for DataFrame[S], LazyFrame[S], GroupBy, and untyped escape hatches.
+
+This file is checked by ty — it must produce zero type errors.
+
+Tests cover:
+- Schema preservation on filter/sort/limit/head/tail/sample/unique/drop_nulls/with_columns
+- Schema-transforming ops (select, group_by+agg) return Any-parameterized frames
+- lazy()/collect() conversions preserve schema
+- GroupBy/LazyGroupBy types
+- UntypedDataFrame/UntypedLazyFrame string-based escape hatches
+- to_typed() re-entry to typed world
+- Negative regression guards (LazyFrame NOT assignable to DataFrame, etc.)
+"""
+
+from colnade import (
+    Column,
+    DataFrame,
+    GroupBy,
+    LazyFrame,
+    LazyGroupBy,
+    Schema,
+    UInt8,
+    UInt64,
+    UntypedDataFrame,
+    UntypedLazyFrame,
+    Utf8,
+)
+
+# --- Schema definitions ---
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+    age: Column[UInt8]
+
+
+class AgeStats(Schema):
+    age: Column[UInt8]
+    count: Column[UInt64]
+
+
+# --- Schema-preserving ops return DataFrame[Users] ---
+
+
+def check_filter_preserves_schema(df: DataFrame[Users]) -> DataFrame[Users]:
+    return df.filter(Users.age > 18)
+
+
+def check_sort_preserves_schema(df: DataFrame[Users]) -> DataFrame[Users]:
+    return df.sort(Users.name)
+
+
+def check_limit_preserves_schema(df: DataFrame[Users]) -> DataFrame[Users]:
+    return df.limit(10)
+
+
+def check_head_preserves_schema(df: DataFrame[Users]) -> DataFrame[Users]:
+    return df.head()
+
+
+def check_tail_preserves_schema(df: DataFrame[Users]) -> DataFrame[Users]:
+    return df.tail()
+
+
+def check_sample_preserves_schema(df: DataFrame[Users]) -> DataFrame[Users]:
+    return df.sample(5)
+
+
+def check_unique_preserves_schema(df: DataFrame[Users]) -> DataFrame[Users]:
+    return df.unique(Users.name)
+
+
+def check_drop_nulls_preserves_schema(df: DataFrame[Users]) -> DataFrame[Users]:
+    return df.drop_nulls(Users.name)
+
+
+def check_with_columns_preserves_schema(df: DataFrame[Users]) -> DataFrame[Users]:
+    return df.with_columns(Users.age + 1)
+
+
+# --- LazyFrame schema-preserving ops ---
+
+
+def check_lazy_filter(lf: LazyFrame[Users]) -> LazyFrame[Users]:
+    return lf.filter(Users.age > 18)
+
+
+def check_lazy_sort(lf: LazyFrame[Users]) -> LazyFrame[Users]:
+    return lf.sort(Users.name)
+
+
+def check_lazy_limit(lf: LazyFrame[Users]) -> LazyFrame[Users]:
+    return lf.limit(10)
+
+
+def check_lazy_unique(lf: LazyFrame[Users]) -> LazyFrame[Users]:
+    return lf.unique(Users.name)
+
+
+def check_lazy_drop_nulls(lf: LazyFrame[Users]) -> LazyFrame[Users]:
+    return lf.drop_nulls(Users.name)
+
+
+def check_lazy_with_columns(lf: LazyFrame[Users]) -> LazyFrame[Users]:
+    return lf.with_columns(Users.age + 1)
+
+
+# --- Conversion preserves schema ---
+
+
+def check_lazy_conversion(df: DataFrame[Users]) -> LazyFrame[Users]:
+    return df.lazy()
+
+
+def check_collect_conversion(lf: LazyFrame[Users]) -> DataFrame[Users]:
+    return lf.collect()
+
+
+# --- GroupBy types ---
+
+
+def check_group_by_type(df: DataFrame[Users]) -> GroupBy[Users]:
+    return df.group_by(Users.age)
+
+
+def check_lazy_group_by_type(lf: LazyFrame[Users]) -> LazyGroupBy[Users]:
+    return lf.group_by(Users.age)
+
+
+# --- Untyped escape hatches ---
+
+
+def check_untyped_dataframe(df: DataFrame[Users]) -> UntypedDataFrame:
+    return df.untyped()
+
+
+def check_untyped_lazyframe(lf: LazyFrame[Users]) -> UntypedLazyFrame:
+    return lf.untyped()
+
+
+def check_untyped_to_typed(udf: UntypedDataFrame) -> DataFrame[Users]:
+    return udf.to_typed(Users)
+
+
+def check_untyped_lazy_to_typed(ulf: UntypedLazyFrame) -> LazyFrame[Users]:
+    return ulf.to_typed(Users)
+
+
+def check_untyped_lazy_collect(ulf: UntypedLazyFrame) -> UntypedDataFrame:
+    return ulf.collect()
+
+
+# --- Validate returns same type ---
+
+
+def check_validate_dataframe(df: DataFrame[Users]) -> DataFrame[Users]:
+    return df.validate()
+
+
+def check_validate_lazyframe(lf: LazyFrame[Users]) -> LazyFrame[Users]:
+    return lf.validate()
+
+
+# ---------------------------------------------------------------------------
+# Negative type tests — regression guards
+#
+# Each line below MUST produce a type error, suppressed by an ignore comment.
+# If types regress, the error disappears, the suppression becomes unused,
+# and ty reports unused-ignore-comment — failing CI.
+# ---------------------------------------------------------------------------
+
+
+def check_neg_lazyframe_not_dataframe() -> None:
+    """LazyFrame[Users] is NOT assignable to DataFrame[Users]."""
+    lf: LazyFrame[Users] = LazyFrame(_schema=Users)
+    _: DataFrame[Users] = lf  # type: ignore[invalid-assignment]
+
+
+def check_neg_dataframe_not_lazyframe() -> None:
+    """DataFrame[Users] is NOT assignable to LazyFrame[Users]."""
+    df: DataFrame[Users] = DataFrame(_schema=Users)
+    _: LazyFrame[Users] = df  # type: ignore[invalid-assignment]
+
+
+def check_neg_untyped_not_dataframe() -> None:
+    """UntypedDataFrame is NOT assignable to DataFrame[Users]."""
+    udf = UntypedDataFrame()
+    _: DataFrame[Users] = udf  # type: ignore[invalid-assignment]
+
+
+def check_neg_groupby_schema_distinct() -> None:
+    """GroupBy[Users] is NOT assignable to GroupBy[AgeStats]."""
+    gb: GroupBy[Users] = GroupBy(_schema=Users)
+    _: GroupBy[AgeStats] = gb  # type: ignore[invalid-assignment]

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -1,0 +1,431 @@
+"""Unit tests for DataFrame[S], LazyFrame[S], GroupBy, and untyped escape hatches."""
+
+from __future__ import annotations
+
+from colnade import (
+    AliasedExpr,
+    Bool,
+    Column,
+    DataFrame,
+    Expr,
+    GroupBy,
+    LazyFrame,
+    LazyGroupBy,
+    Schema,
+    UInt8,
+    UInt64,
+    UntypedDataFrame,
+    UntypedLazyFrame,
+    Utf8,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixture schemas
+# ---------------------------------------------------------------------------
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+    age: Column[UInt8]
+
+
+class AgeStats(Schema):
+    age: Column[UInt8]
+    count: Column[UInt64]
+
+
+# ---------------------------------------------------------------------------
+# DataFrame construction
+# ---------------------------------------------------------------------------
+
+
+class TestDataFrameConstruction:
+    def test_default_construction(self) -> None:
+        df: DataFrame[Users] = DataFrame()
+        assert isinstance(df, DataFrame)
+
+    def test_schema_stored(self) -> None:
+        df = DataFrame(_schema=Users)
+        assert df._schema is Users
+
+    def test_data_stored(self) -> None:
+        sentinel = object()
+        df = DataFrame(_data=sentinel)
+        assert df._data is sentinel
+
+    def test_repr_with_schema(self) -> None:
+        df = DataFrame(_schema=Users)
+        assert repr(df) == "DataFrame[Users]"
+
+    def test_repr_without_schema(self) -> None:
+        df = DataFrame()
+        assert repr(df) == "DataFrame[Any]"
+
+
+# ---------------------------------------------------------------------------
+# Schema-preserving operations
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaPreservingOps:
+    def setup_method(self) -> None:
+        self.df: DataFrame[Users] = DataFrame(_schema=Users)
+
+    def test_filter_returns_dataframe(self) -> None:
+        predicate: Expr[Bool] = Users.age > 18
+        result = self.df.filter(predicate)
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+    def test_sort_returns_dataframe(self) -> None:
+        result = self.df.sort(Users.name)
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+    def test_sort_with_sort_expr(self) -> None:
+        result = self.df.sort(Users.name.desc())
+        assert isinstance(result, DataFrame)
+
+    def test_sort_descending_kwarg(self) -> None:
+        result = self.df.sort(Users.name, descending=True)
+        assert isinstance(result, DataFrame)
+
+    def test_limit_returns_dataframe(self) -> None:
+        result = self.df.limit(10)
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+    def test_head_returns_dataframe(self) -> None:
+        result = self.df.head()
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+    def test_head_with_n(self) -> None:
+        result = self.df.head(10)
+        assert isinstance(result, DataFrame)
+
+    def test_tail_returns_dataframe(self) -> None:
+        result = self.df.tail()
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+    def test_tail_with_n(self) -> None:
+        result = self.df.tail(10)
+        assert isinstance(result, DataFrame)
+
+    def test_sample_returns_dataframe(self) -> None:
+        result = self.df.sample(5)
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+    def test_unique_returns_dataframe(self) -> None:
+        result = self.df.unique(Users.name)
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+    def test_unique_multiple_columns(self) -> None:
+        result = self.df.unique(Users.name, Users.age)
+        assert isinstance(result, DataFrame)
+
+    def test_drop_nulls_returns_dataframe(self) -> None:
+        result = self.df.drop_nulls(Users.name)
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+    def test_with_columns_returns_dataframe(self) -> None:
+        expr = Users.age + 1
+        result = self.df.with_columns(expr)
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+    def test_with_columns_aliased(self) -> None:
+        aliased: AliasedExpr[UInt8] = (Users.age + 1).alias("age_plus_one")
+        result = self.df.with_columns(aliased)
+        assert isinstance(result, DataFrame)
+
+
+# ---------------------------------------------------------------------------
+# Schema-transforming operations
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaTransformingOps:
+    def setup_method(self) -> None:
+        self.df: DataFrame[Users] = DataFrame(_schema=Users)
+
+    def test_select_single_column(self) -> None:
+        result = self.df.select(Users.name)
+        assert isinstance(result, DataFrame)
+        assert result._schema is None
+
+    def test_select_multiple_columns(self) -> None:
+        result = self.df.select(Users.name, Users.age)
+        assert isinstance(result, DataFrame)
+        assert result._schema is None
+
+    def test_select_all_columns(self) -> None:
+        result = self.df.select(Users.id, Users.name, Users.age)
+        assert isinstance(result, DataFrame)
+
+    def test_group_by_agg(self) -> None:
+        result = self.df.group_by(Users.age).agg(Users.id.count().alias("count"))
+        assert isinstance(result, DataFrame)
+        assert result._schema is None
+
+
+# ---------------------------------------------------------------------------
+# GroupBy
+# ---------------------------------------------------------------------------
+
+
+class TestGroupBy:
+    def test_group_by_returns_groupby(self) -> None:
+        df: DataFrame[Users] = DataFrame(_schema=Users)
+        gb = df.group_by(Users.age)
+        assert isinstance(gb, GroupBy)
+
+    def test_group_by_keys_stored(self) -> None:
+        df: DataFrame[Users] = DataFrame(_schema=Users)
+        gb = df.group_by(Users.age, Users.name)
+        assert gb._keys == (Users.age, Users.name)
+
+    def test_group_by_schema_stored(self) -> None:
+        df: DataFrame[Users] = DataFrame(_schema=Users)
+        gb = df.group_by(Users.age)
+        assert gb._schema is Users
+
+    def test_agg_returns_dataframe(self) -> None:
+        df: DataFrame[Users] = DataFrame(_schema=Users)
+        result = df.group_by(Users.age).agg(Users.id.count().alias("count"))
+        assert isinstance(result, DataFrame)
+        assert result._schema is None
+
+    def test_agg_multiple_exprs(self) -> None:
+        df: DataFrame[Users] = DataFrame(_schema=Users)
+        result = df.group_by(Users.age).agg(
+            Users.id.count().alias("count"),
+            Users.name.count().alias("name_count"),
+        )
+        assert isinstance(result, DataFrame)
+
+
+# ---------------------------------------------------------------------------
+# Conversion: lazy, untyped, collect
+# ---------------------------------------------------------------------------
+
+
+class TestConversion:
+    def test_lazy_returns_lazyframe(self) -> None:
+        df: DataFrame[Users] = DataFrame(_schema=Users)
+        result = df.lazy()
+        assert isinstance(result, LazyFrame)
+        assert result._schema is Users
+
+    def test_untyped_returns_untyped(self) -> None:
+        df: DataFrame[Users] = DataFrame(_schema=Users)
+        result = df.untyped()
+        assert isinstance(result, UntypedDataFrame)
+
+    def test_collect_returns_dataframe(self) -> None:
+        lf: LazyFrame[Users] = LazyFrame(_schema=Users)
+        result = lf.collect()
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+    def test_validate_returns_self(self) -> None:
+        df: DataFrame[Users] = DataFrame(_schema=Users)
+        result = df.validate()
+        assert result is df
+
+    def test_to_batches_not_implemented(self) -> None:
+        import pytest
+
+        df: DataFrame[Users] = DataFrame(_schema=Users)
+        with pytest.raises(NotImplementedError):
+            df.to_batches()
+
+
+# ---------------------------------------------------------------------------
+# LazyFrame operations
+# ---------------------------------------------------------------------------
+
+
+class TestLazyFrame:
+    def setup_method(self) -> None:
+        self.lf: LazyFrame[Users] = LazyFrame(_schema=Users)
+
+    def test_repr_with_schema(self) -> None:
+        assert repr(self.lf) == "LazyFrame[Users]"
+
+    def test_repr_without_schema(self) -> None:
+        lf = LazyFrame()
+        assert repr(lf) == "LazyFrame[Any]"
+
+    def test_filter_returns_lazyframe(self) -> None:
+        result = self.lf.filter(Users.age > 18)
+        assert isinstance(result, LazyFrame)
+        assert result._schema is Users
+
+    def test_sort_returns_lazyframe(self) -> None:
+        result = self.lf.sort(Users.name)
+        assert isinstance(result, LazyFrame)
+        assert result._schema is Users
+
+    def test_limit_returns_lazyframe(self) -> None:
+        result = self.lf.limit(10)
+        assert isinstance(result, LazyFrame)
+        assert result._schema is Users
+
+    def test_unique_returns_lazyframe(self) -> None:
+        result = self.lf.unique(Users.name)
+        assert isinstance(result, LazyFrame)
+
+    def test_drop_nulls_returns_lazyframe(self) -> None:
+        result = self.lf.drop_nulls(Users.name)
+        assert isinstance(result, LazyFrame)
+
+    def test_with_columns_returns_lazyframe(self) -> None:
+        result = self.lf.with_columns(Users.age + 1)
+        assert isinstance(result, LazyFrame)
+
+    def test_select_returns_lazyframe(self) -> None:
+        result = self.lf.select(Users.name, Users.age)
+        assert isinstance(result, LazyFrame)
+        assert result._schema is None
+
+    def test_group_by_returns_lazy_groupby(self) -> None:
+        gb = self.lf.group_by(Users.age)
+        assert isinstance(gb, LazyGroupBy)
+
+    def test_collect_returns_dataframe(self) -> None:
+        result = self.lf.collect()
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+    def test_untyped_returns_untyped_lazy(self) -> None:
+        result = self.lf.untyped()
+        assert isinstance(result, UntypedLazyFrame)
+
+    def test_validate_returns_self(self) -> None:
+        result = self.lf.validate()
+        assert result is self.lf
+
+
+# ---------------------------------------------------------------------------
+# LazyFrame restrictions (no head, tail, sample)
+# ---------------------------------------------------------------------------
+
+
+class TestLazyFrameRestrictions:
+    def test_no_head(self) -> None:
+        assert not hasattr(LazyFrame, "head")
+
+    def test_no_tail(self) -> None:
+        assert not hasattr(LazyFrame, "tail")
+
+    def test_no_sample(self) -> None:
+        assert not hasattr(LazyFrame, "sample")
+
+    def test_no_to_batches(self) -> None:
+        assert not hasattr(LazyFrame, "to_batches")
+
+
+# ---------------------------------------------------------------------------
+# LazyGroupBy
+# ---------------------------------------------------------------------------
+
+
+class TestLazyGroupBy:
+    def test_lazy_groupby_agg_returns_lazyframe(self) -> None:
+        lf: LazyFrame[Users] = LazyFrame(_schema=Users)
+        result = lf.group_by(Users.age).agg(Users.id.count().alias("count"))
+        assert isinstance(result, LazyFrame)
+        assert result._schema is None
+
+    def test_lazy_groupby_keys_stored(self) -> None:
+        lf: LazyFrame[Users] = LazyFrame(_schema=Users)
+        gb = lf.group_by(Users.age, Users.name)
+        assert gb._keys == (Users.age, Users.name)
+
+
+# ---------------------------------------------------------------------------
+# UntypedDataFrame
+# ---------------------------------------------------------------------------
+
+
+class TestUntypedDataFrame:
+    def setup_method(self) -> None:
+        self.udf = UntypedDataFrame()
+
+    def test_select_returns_untyped(self) -> None:
+        result = self.udf.select("name", "age")
+        assert isinstance(result, UntypedDataFrame)
+
+    def test_filter_returns_untyped(self) -> None:
+        result = self.udf.filter("age > 18")
+        assert isinstance(result, UntypedDataFrame)
+
+    def test_with_columns_returns_untyped(self) -> None:
+        result = self.udf.with_columns("something")
+        assert isinstance(result, UntypedDataFrame)
+
+    def test_sort_returns_untyped(self) -> None:
+        result = self.udf.sort("name")
+        assert isinstance(result, UntypedDataFrame)
+
+    def test_limit_returns_untyped(self) -> None:
+        result = self.udf.limit(10)
+        assert isinstance(result, UntypedDataFrame)
+
+    def test_head_returns_untyped(self) -> None:
+        result = self.udf.head()
+        assert isinstance(result, UntypedDataFrame)
+
+    def test_tail_returns_untyped(self) -> None:
+        result = self.udf.tail()
+        assert isinstance(result, UntypedDataFrame)
+
+    def test_to_typed_returns_dataframe(self) -> None:
+        result = self.udf.to_typed(Users)
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+
+
+# ---------------------------------------------------------------------------
+# UntypedLazyFrame
+# ---------------------------------------------------------------------------
+
+
+class TestUntypedLazyFrame:
+    def setup_method(self) -> None:
+        self.ulf = UntypedLazyFrame()
+
+    def test_select_returns_untyped_lazy(self) -> None:
+        result = self.ulf.select("name")
+        assert isinstance(result, UntypedLazyFrame)
+
+    def test_filter_returns_untyped_lazy(self) -> None:
+        result = self.ulf.filter("age > 18")
+        assert isinstance(result, UntypedLazyFrame)
+
+    def test_with_columns_returns_untyped_lazy(self) -> None:
+        result = self.ulf.with_columns("something")
+        assert isinstance(result, UntypedLazyFrame)
+
+    def test_sort_returns_untyped_lazy(self) -> None:
+        result = self.ulf.sort("name")
+        assert isinstance(result, UntypedLazyFrame)
+
+    def test_limit_returns_untyped_lazy(self) -> None:
+        result = self.ulf.limit(10)
+        assert isinstance(result, UntypedLazyFrame)
+
+    def test_collect_returns_untyped_dataframe(self) -> None:
+        result = self.ulf.collect()
+        assert isinstance(result, UntypedDataFrame)
+
+    def test_to_typed_returns_lazyframe(self) -> None:
+        result = self.ulf.to_typed(Users)
+        assert isinstance(result, LazyFrame)
+        assert result._schema is Users


### PR DESCRIPTION
## Summary

- Implement `DataFrame[S]` and `LazyFrame[S]` generic interfaces with all schema-preserving ops (`filter`, `sort`, `limit`, `head`, `tail`, `sample`, `unique`, `drop_nulls`, `with_columns`) and schema-transforming ops (`select` with 5 overloads, `group_by`+`agg`)
- Add `GroupBy[S]` / `LazyGroupBy[S]` with `agg()` returning `DataFrame[Any]` / `LazyFrame[Any]`
- Add `UntypedDataFrame` / `UntypedLazyFrame` string-based escape hatches with `to_typed()` re-entry
- LazyFrame correctly omits materialized-only ops (`head`, `tail`, `sample`, `to_batches`)
- 68 unit tests + 22 static type tests (4 negative regression guards)

**Limitation note:** `Column[DType]` has a single type parameter (no schema binding), so `select()`, `sort()`, `group_by()` accept `Column[Any]` and cannot statically enforce that columns belong to the DataFrame's schema. Same root cause as PR #17's self-narrowing limitation.

Closes #6

## Test plan

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run pytest tests/ -v` — 220/220 passed
- [x] `uv run ty check src/colnade/` — all checks passed
- [x] `uv run ty check tests/typing/` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)