### PR TITLE
Implement join system (#7)

### DIFF
--- a/src/colnade/__init__.py
+++ b/src/colnade/__init__.py
@@ -3,6 +3,8 @@
 from colnade.dataframe import (
     DataFrame,
     GroupBy,
+    JoinedDataFrame,
+    JoinedLazyFrame,
     LazyFrame,
     LazyGroupBy,
     UntypedDataFrame,
@@ -40,6 +42,7 @@ from colnade.expr import (
     ColumnRef,
     Expr,
     FunctionCall,
+    JoinCondition,
     ListOp,
     Literal,
     SortExpr,
@@ -59,6 +62,8 @@ __all__ = [
     "LazyFrame",
     "GroupBy",
     "LazyGroupBy",
+    "JoinedDataFrame",
+    "JoinedLazyFrame",
     "UntypedDataFrame",
     "UntypedLazyFrame",
     # Expression DSL
@@ -73,6 +78,7 @@ __all__ = [
     "SortExpr",
     "StructFieldAccess",
     "ListOp",
+    "JoinCondition",
     "lit",
     # Type categories
     "NumericType",

--- a/src/colnade/expr.py
+++ b/src/colnade/expr.py
@@ -269,6 +269,31 @@ class ListOp(Expr[DType]):
 
 
 # ---------------------------------------------------------------------------
+# Join condition (not an Expr — a join predicate)
+# ---------------------------------------------------------------------------
+
+
+class JoinCondition:
+    """A join predicate from comparing columns of two different schemas.
+
+    Created by ``Column.__eq__`` when the two columns belong to different
+    schemas::
+
+        Users.id == Orders.user_id  # → JoinCondition
+        Users.age == Users.score    # → BinOp[Bool] (same schema)
+    """
+
+    __slots__ = ("left", "right")
+
+    def __init__(self, left: Column[Any], right: Column[Any]) -> None:
+        self.left = left
+        self.right = right
+
+    def __repr__(self) -> str:
+        return f"JoinCondition({self.left.name!r} == {self.right.name!r})"
+
+
+# ---------------------------------------------------------------------------
 # Helper
 # ---------------------------------------------------------------------------
 

--- a/src/colnade/schema.py
+++ b/src/colnade/schema.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         BinOp,
         ColumnRef,
         FunctionCall,
+        JoinCondition,
         ListOp,
         SortExpr,
         StructFieldAccess,
@@ -120,7 +121,11 @@ class Column(Generic[DType]):
     def __le__(self, other: Any) -> BinOp[Bool]:
         return self._binop(other, "<=")
 
-    def __eq__(self, other: Any) -> BinOp[Bool]:  # type: ignore[override]
+    def __eq__(self, other: Any) -> BinOp[Bool] | JoinCondition:  # type: ignore[override]
+        if isinstance(other, Column) and self.schema is not other.schema:
+            from colnade.expr import JoinCondition as _JoinCondition
+
+            return _JoinCondition(left=self, right=other)
         return self._binop(other, "==")
 
     def __ne__(self, other: Any) -> BinOp[Bool]:  # type: ignore[override]

--- a/tests/typing/test_join.py
+++ b/tests/typing/test_join.py
@@ -1,0 +1,160 @@
+"""Static type tests for the join system.
+
+This file is checked by ty — it must produce zero type errors.
+
+Tests cover:
+- JoinCondition creation from cross-schema ==
+- .join() return types on DataFrame and LazyFrame
+- JoinedDataFrame schema-preserving ops
+- JoinedLazyFrame ops and collect()
+- Conversions (lazy, untyped)
+- Negative regression guards
+"""
+
+from typing import Any
+
+from colnade import (
+    Column,
+    DataFrame,
+    JoinCondition,
+    JoinedDataFrame,
+    JoinedLazyFrame,
+    LazyFrame,
+    Schema,
+    UInt64,
+    UntypedDataFrame,
+    UntypedLazyFrame,
+    Utf8,
+)
+
+# --- Schema definitions ---
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+    age: Column[UInt64]
+
+
+class Orders(Schema):
+    id: Column[UInt64]
+    user_id: Column[UInt64]
+    amount: Column[UInt64]
+
+
+# --- Join return types ---
+
+
+def check_dataframe_join(
+    df: DataFrame[Users], orders: DataFrame[Orders], cond: JoinCondition
+) -> JoinedDataFrame[Users, Orders]:
+    return df.join(orders, on=cond)
+
+
+def check_lazyframe_join(
+    lf: LazyFrame[Users], orders: LazyFrame[Orders], cond: JoinCondition
+) -> JoinedLazyFrame[Users, Orders]:
+    return lf.join(orders, on=cond)
+
+
+# --- JoinedDataFrame schema-preserving ops ---
+
+
+def check_joined_filter(
+    j: JoinedDataFrame[Users, Orders],
+) -> JoinedDataFrame[Users, Orders]:
+    return j.filter(Users.age > 18)
+
+
+def check_joined_sort(
+    j: JoinedDataFrame[Users, Orders],
+) -> JoinedDataFrame[Users, Orders]:
+    return j.sort(Users.name)
+
+
+def check_joined_limit(
+    j: JoinedDataFrame[Users, Orders],
+) -> JoinedDataFrame[Users, Orders]:
+    return j.limit(10)
+
+
+def check_joined_unique(
+    j: JoinedDataFrame[Users, Orders],
+) -> JoinedDataFrame[Users, Orders]:
+    return j.unique(Users.id)
+
+
+def check_joined_drop_nulls(
+    j: JoinedDataFrame[Users, Orders],
+) -> JoinedDataFrame[Users, Orders]:
+    return j.drop_nulls(Users.name)
+
+
+def check_joined_with_columns(
+    j: JoinedDataFrame[Users, Orders],
+) -> JoinedDataFrame[Users, Orders]:
+    return j.with_columns(Users.age + 1)
+
+
+# --- JoinedDataFrame select returns DataFrame[Any] ---
+
+
+def check_joined_select(j: JoinedDataFrame[Users, Orders]) -> None:
+    _: DataFrame[Any] = j.select(Users.name, Orders.amount)
+
+
+# --- JoinedDataFrame conversions ---
+
+
+def check_joined_lazy(
+    j: JoinedDataFrame[Users, Orders],
+) -> JoinedLazyFrame[Users, Orders]:
+    return j.lazy()
+
+
+def check_joined_untyped(j: JoinedDataFrame[Users, Orders]) -> UntypedDataFrame:
+    return j.untyped()
+
+
+# --- JoinedLazyFrame ops ---
+
+
+def check_joined_lazy_filter(
+    j: JoinedLazyFrame[Users, Orders],
+) -> JoinedLazyFrame[Users, Orders]:
+    return j.filter(Users.age > 18)
+
+
+def check_joined_lazy_collect(
+    j: JoinedLazyFrame[Users, Orders],
+) -> JoinedDataFrame[Users, Orders]:
+    return j.collect()
+
+
+def check_joined_lazy_untyped(
+    j: JoinedLazyFrame[Users, Orders],
+) -> UntypedLazyFrame:
+    return j.untyped()
+
+
+# ---------------------------------------------------------------------------
+# Negative type tests — regression guards
+# ---------------------------------------------------------------------------
+
+
+def check_neg_joined_not_dataframe() -> None:
+    """JoinedDataFrame[Users, Orders] is NOT assignable to DataFrame[Users]."""
+    j: JoinedDataFrame[Users, Orders] = JoinedDataFrame(_schema_left=Users, _schema_right=Orders)
+    _: DataFrame[Users] = j  # type: ignore[invalid-assignment]
+
+
+def check_neg_joined_lazy_not_joined() -> None:
+    """JoinedLazyFrame is NOT assignable to JoinedDataFrame."""
+    jl: JoinedLazyFrame[Users, Orders] = JoinedLazyFrame(_schema_left=Users, _schema_right=Orders)
+    _: JoinedDataFrame[Users, Orders] = jl  # type: ignore[invalid-assignment]
+
+
+def check_neg_joined_order_matters() -> None:
+    """JoinedDataFrame[Users, Orders] is NOT assignable to JoinedDataFrame[Orders, Users]."""
+    j: JoinedDataFrame[Users, Orders] = JoinedDataFrame(_schema_left=Users, _schema_right=Orders)
+    _: JoinedDataFrame[Orders, Users] = j  # type: ignore[invalid-assignment]

--- a/tests/unit/test_join.py
+++ b/tests/unit/test_join.py
@@ -1,0 +1,277 @@
+"""Unit tests for the join system — JoinCondition, JoinedDataFrame, JoinedLazyFrame."""
+
+from __future__ import annotations
+
+from colnade import (
+    BinOp,
+    Column,
+    DataFrame,
+    JoinCondition,
+    JoinedDataFrame,
+    JoinedLazyFrame,
+    LazyFrame,
+    Schema,
+    UInt64,
+    UntypedDataFrame,
+    UntypedLazyFrame,
+    Utf8,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixture schemas
+# ---------------------------------------------------------------------------
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+    age: Column[UInt64]
+
+
+class Orders(Schema):
+    id: Column[UInt64]
+    user_id: Column[UInt64]
+    amount: Column[UInt64]
+
+
+# ---------------------------------------------------------------------------
+# JoinCondition creation and __eq__ dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestJoinCondition:
+    def test_cross_schema_eq_returns_join_condition(self) -> None:
+        result = Users.id == Orders.user_id
+        assert isinstance(result, JoinCondition)
+
+    def test_join_condition_stores_left(self) -> None:
+        result = Users.id == Orders.user_id
+        assert result.left is Users.id
+
+    def test_join_condition_stores_right(self) -> None:
+        result = Users.id == Orders.user_id
+        assert result.right is Orders.user_id
+
+    def test_same_schema_eq_returns_binop(self) -> None:
+        result = Users.age == Users.id
+        assert isinstance(result, BinOp)
+
+    def test_same_schema_eq_not_join_condition(self) -> None:
+        result = Users.age == Users.id
+        assert not isinstance(result, JoinCondition)
+
+    def test_column_vs_literal_returns_binop(self) -> None:
+        result = Users.age == 25
+        assert isinstance(result, BinOp)
+
+    def test_join_condition_repr(self) -> None:
+        result = Users.id == Orders.user_id
+        r = repr(result)
+        assert "JoinCondition" in r
+        assert "id" in r
+        assert "user_id" in r
+
+
+# ---------------------------------------------------------------------------
+# JoinedDataFrame — construction and operations
+# ---------------------------------------------------------------------------
+
+
+class TestJoinedDataFrame:
+    def setup_method(self) -> None:
+        self.users_df: DataFrame[Users] = DataFrame(_schema=Users)
+        self.orders_df: DataFrame[Orders] = DataFrame(_schema=Orders)
+        self.cond = Users.id == Orders.user_id
+        assert isinstance(self.cond, JoinCondition)
+        self.joined = self.users_df.join(self.orders_df, on=self.cond)
+
+    def test_join_returns_joined_dataframe(self) -> None:
+        assert isinstance(self.joined, JoinedDataFrame)
+
+    def test_joined_stores_schemas(self) -> None:
+        assert self.joined._schema_left is Users
+        assert self.joined._schema_right is Orders
+
+    def test_repr(self) -> None:
+        assert repr(self.joined) == "JoinedDataFrame[Users, Orders]"
+
+    def test_filter_returns_joined(self) -> None:
+        result = self.joined.filter(Users.age > 18)
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_sort_returns_joined(self) -> None:
+        result = self.joined.sort(Users.name)
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_sort_with_right_schema_col(self) -> None:
+        result = self.joined.sort(Orders.amount)
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_limit_returns_joined(self) -> None:
+        result = self.joined.limit(10)
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_head_returns_joined(self) -> None:
+        result = self.joined.head()
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_tail_returns_joined(self) -> None:
+        result = self.joined.tail()
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_sample_returns_joined(self) -> None:
+        result = self.joined.sample(5)
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_unique_returns_joined(self) -> None:
+        result = self.joined.unique(Users.id)
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_drop_nulls_returns_joined(self) -> None:
+        result = self.joined.drop_nulls(Users.name)
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_with_columns_returns_joined(self) -> None:
+        result = self.joined.with_columns(Users.age + 1)
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_select_returns_dataframe(self) -> None:
+        result = self.joined.select(Users.name, Orders.amount)
+        assert isinstance(result, DataFrame)
+        assert result._schema is None
+
+    def test_select_single_column(self) -> None:
+        result = self.joined.select(Users.name)
+        assert isinstance(result, DataFrame)
+
+
+# ---------------------------------------------------------------------------
+# JoinedDataFrame — conversions
+# ---------------------------------------------------------------------------
+
+
+class TestJoinedDataFrameConversions:
+    def setup_method(self) -> None:
+        self.joined = JoinedDataFrame(_schema_left=Users, _schema_right=Orders)
+
+    def test_lazy_returns_joined_lazyframe(self) -> None:
+        result = self.joined.lazy()
+        assert isinstance(result, JoinedLazyFrame)
+        assert result._schema_left is Users
+        assert result._schema_right is Orders
+
+    def test_untyped_returns_untyped(self) -> None:
+        result = self.joined.untyped()
+        assert isinstance(result, UntypedDataFrame)
+
+
+# ---------------------------------------------------------------------------
+# JoinedLazyFrame — construction and operations
+# ---------------------------------------------------------------------------
+
+
+class TestJoinedLazyFrame:
+    def setup_method(self) -> None:
+        self.users_lf: LazyFrame[Users] = LazyFrame(_schema=Users)
+        self.orders_lf: LazyFrame[Orders] = LazyFrame(_schema=Orders)
+        self.cond = Users.id == Orders.user_id
+        assert isinstance(self.cond, JoinCondition)
+        self.joined = self.users_lf.join(self.orders_lf, on=self.cond)
+
+    def test_join_returns_joined_lazyframe(self) -> None:
+        assert isinstance(self.joined, JoinedLazyFrame)
+
+    def test_joined_stores_schemas(self) -> None:
+        assert self.joined._schema_left is Users
+        assert self.joined._schema_right is Orders
+
+    def test_repr(self) -> None:
+        assert repr(self.joined) == "JoinedLazyFrame[Users, Orders]"
+
+    def test_filter_returns_joined_lazy(self) -> None:
+        result = self.joined.filter(Users.age > 18)
+        assert isinstance(result, JoinedLazyFrame)
+
+    def test_sort_returns_joined_lazy(self) -> None:
+        result = self.joined.sort(Users.name)
+        assert isinstance(result, JoinedLazyFrame)
+
+    def test_limit_returns_joined_lazy(self) -> None:
+        result = self.joined.limit(10)
+        assert isinstance(result, JoinedLazyFrame)
+
+    def test_unique_returns_joined_lazy(self) -> None:
+        result = self.joined.unique(Users.id)
+        assert isinstance(result, JoinedLazyFrame)
+
+    def test_drop_nulls_returns_joined_lazy(self) -> None:
+        result = self.joined.drop_nulls(Users.name)
+        assert isinstance(result, JoinedLazyFrame)
+
+    def test_with_columns_returns_joined_lazy(self) -> None:
+        result = self.joined.with_columns(Users.age + 1)
+        assert isinstance(result, JoinedLazyFrame)
+
+    def test_select_returns_lazyframe(self) -> None:
+        result = self.joined.select(Users.name, Orders.amount)
+        assert isinstance(result, LazyFrame)
+        assert result._schema is None
+
+    def test_collect_returns_joined_dataframe(self) -> None:
+        result = self.joined.collect()
+        assert isinstance(result, JoinedDataFrame)
+        assert result._schema_left is Users
+        assert result._schema_right is Orders
+
+    def test_untyped_returns_untyped_lazy(self) -> None:
+        result = self.joined.untyped()
+        assert isinstance(result, UntypedLazyFrame)
+
+
+# ---------------------------------------------------------------------------
+# JoinedLazyFrame restrictions
+# ---------------------------------------------------------------------------
+
+
+class TestJoinedLazyFrameRestrictions:
+    def test_no_head(self) -> None:
+        assert not hasattr(JoinedLazyFrame, "head")
+
+    def test_no_tail(self) -> None:
+        assert not hasattr(JoinedLazyFrame, "tail")
+
+    def test_no_sample(self) -> None:
+        assert not hasattr(JoinedLazyFrame, "sample")
+
+
+# ---------------------------------------------------------------------------
+# Join how parameter
+# ---------------------------------------------------------------------------
+
+
+class TestJoinHow:
+    def setup_method(self) -> None:
+        self.users_df: DataFrame[Users] = DataFrame(_schema=Users)
+        self.orders_df: DataFrame[Orders] = DataFrame(_schema=Orders)
+        self.cond = Users.id == Orders.user_id
+        assert isinstance(self.cond, JoinCondition)
+
+    def test_inner(self) -> None:
+        result = self.users_df.join(self.orders_df, on=self.cond, how="inner")
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_left(self) -> None:
+        result = self.users_df.join(self.orders_df, on=self.cond, how="left")
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_outer(self) -> None:
+        result = self.users_df.join(self.orders_df, on=self.cond, how="outer")
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_cross(self) -> None:
+        result = self.users_df.join(self.orders_df, on=self.cond, how="cross")
+        assert isinstance(result, JoinedDataFrame)
+
+    def test_default_is_inner(self) -> None:
+        result = self.users_df.join(self.orders_df, on=self.cond)
+        assert isinstance(result, JoinedDataFrame)


### PR DESCRIPTION
## Summary

- Add `JoinCondition` class (in `expr.py`) — a join predicate produced by cross-schema `==` comparison
- Modify `Column.__eq__` with runtime dispatch: same-schema → `BinOp[Bool]`, different-schema → `JoinCondition`
- Add `JoinedDataFrame[S, S2]` and `JoinedLazyFrame[S, S2]` with schema-preserving ops (filter, sort, limit, head, tail, sample, unique, drop_nulls, with_columns), select overloads, and conversions (lazy/collect/untyped)
- Add `.join(other, on, how)` methods to `DataFrame` and `LazyFrame` accepting `how: Literal["inner", "left", "outer", "cross"]`
- JoinedLazyFrame correctly omits materialized-only ops (head, tail, sample)
- 44 unit tests + 18 static type tests (3 negative regression guards)

**Limitation:** `Column[DType]` has no schema type parameter, so JoinedDataFrame methods accept `Column[Any]` — cannot statically reject columns from a third schema. Same root cause as prior limitations.

Closes #7

## Test plan

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — all files formatted
- [x] `uv run pytest tests/ -v` — 264/264 passed
- [x] `uv run ty check src/colnade/` — all checks passed
- [x] `uv run ty check tests/typing/` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)