### PR TITLE
Implement cast_schema, mapped_from & SchemaError

### DIFF
--- a/src/colnade/__init__.py
+++ b/src/colnade/__init__.py
@@ -50,13 +50,15 @@ from colnade.expr import (
     UnaryOp,
     lit,
 )
-from colnade.schema import Column, ListAccessor, Schema
+from colnade.schema import Column, ListAccessor, Schema, SchemaError, mapped_from
 
 __all__ = [
     # Schema layer
     "Schema",
     "Column",
     "ListAccessor",
+    "mapped_from",
+    "SchemaError",
     # DataFrame layer
     "DataFrame",
     "LazyFrame",

--- a/tests/typing/test_cast_schema.py
+++ b/tests/typing/test_cast_schema.py
@@ -1,0 +1,107 @@
+"""Static type tests for cast_schema, mapped_from, and SchemaError.
+
+This file is checked by ty — it must produce zero type errors.
+"""
+
+from typing import Any
+
+from colnade import (
+    Column,
+    DataFrame,
+    JoinedDataFrame,
+    JoinedLazyFrame,
+    LazyFrame,
+    Schema,
+    UInt64,
+    Utf8,
+    mapped_from,
+)
+
+# --- Schema definitions ---
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+
+
+class Orders(Schema):
+    id: Column[UInt64]
+    user_id: Column[UInt64]
+    amount: Column[UInt64]
+
+
+class UsersSummary(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+
+
+class RenamedUsers(Schema):
+    user_id: Column[UInt64] = mapped_from(Users.id)
+    user_name: Column[Utf8] = mapped_from(Users.name)
+
+
+# --- Positive: DataFrame.cast_schema ---
+
+
+def check_df_cast_schema(df: DataFrame[Users]) -> DataFrame[UsersSummary]:
+    return df.cast_schema(UsersSummary)
+
+
+def check_df_cast_schema_renamed(df: DataFrame[Users]) -> DataFrame[RenamedUsers]:
+    return df.cast_schema(RenamedUsers)
+
+
+# --- Positive: LazyFrame.cast_schema ---
+
+
+def check_lf_cast_schema(lf: LazyFrame[Users]) -> LazyFrame[UsersSummary]:
+    return lf.cast_schema(UsersSummary)
+
+
+# --- Positive: JoinedDataFrame.cast_schema → DataFrame ---
+
+
+def check_joined_cast_schema(
+    j: JoinedDataFrame[Users, Orders],
+) -> DataFrame[UsersSummary]:
+    return j.cast_schema(UsersSummary)
+
+
+# --- Positive: JoinedLazyFrame.cast_schema → LazyFrame ---
+
+
+def check_joined_lazy_cast_schema(
+    j: JoinedLazyFrame[Users, Orders],
+) -> LazyFrame[UsersSummary]:
+    return j.cast_schema(UsersSummary)
+
+
+# --- Positive: mapped_from preserves Column type ---
+
+
+def check_mapped_from_type() -> Column[UInt64]:
+    return mapped_from(Users.id)
+
+
+def check_mapped_from_utf8() -> Column[Utf8]:
+    return mapped_from(Users.name)
+
+
+# ---------------------------------------------------------------------------
+# Negative type tests — regression guards
+# ---------------------------------------------------------------------------
+
+
+def check_neg_joined_cast_not_joined() -> None:
+    """JoinedDataFrame.cast_schema returns DataFrame, NOT JoinedDataFrame."""
+    j: JoinedDataFrame[Users, Orders] = JoinedDataFrame(_schema_left=Users, _schema_right=Orders)
+    result = j.cast_schema(UsersSummary)
+    _: JoinedDataFrame[Any, Any] = result  # type: ignore[invalid-assignment]
+
+
+def check_neg_joined_lazy_cast_not_joined() -> None:
+    """JoinedLazyFrame.cast_schema returns LazyFrame, NOT JoinedLazyFrame."""
+    j: JoinedLazyFrame[Users, Orders] = JoinedLazyFrame(_schema_left=Users, _schema_right=Orders)
+    result = j.cast_schema(UsersSummary)
+    _: JoinedLazyFrame[Any, Any] = result  # type: ignore[invalid-assignment]

--- a/tests/unit/test_cast_schema.py
+++ b/tests/unit/test_cast_schema.py
@@ -1,0 +1,314 @@
+"""Unit tests for cast_schema, mapped_from, and SchemaError."""
+
+from __future__ import annotations
+
+import pytest
+
+from colnade import (
+    Column,
+    DataFrame,
+    JoinedDataFrame,
+    JoinedLazyFrame,
+    LazyFrame,
+    Schema,
+    SchemaError,
+    UInt64,
+    Utf8,
+    mapped_from,
+)
+from colnade.schema import _MappedFrom
+
+# ---------------------------------------------------------------------------
+# Test fixture schemas
+# ---------------------------------------------------------------------------
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+    age: Column[UInt64]
+
+
+class Orders(Schema):
+    id: Column[UInt64]
+    user_id: Column[UInt64]
+    amount: Column[UInt64]
+
+
+# Target schemas for cast_schema tests
+
+
+class UsersSummary(Schema):
+    """Same column names as Users — name-matching should resolve."""
+
+    id: Column[UInt64]
+    name: Column[Utf8]
+
+
+class RenamedUsers(Schema):
+    """Uses mapped_from to rename columns."""
+
+    user_id: Column[UInt64] = mapped_from(Users.id)
+    user_name: Column[Utf8] = mapped_from(Users.name)
+
+
+class MixedMapping(Schema):
+    """Mix of mapped_from and name-matched columns."""
+
+    id: Column[UInt64]
+    user_name: Column[Utf8] = mapped_from(Users.name)
+
+
+class JoinTarget(Schema):
+    """Target for joined cast_schema — columns from both schemas."""
+
+    user_name: Column[Utf8] = mapped_from(Users.name)
+    user_id: Column[UInt64] = mapped_from(Orders.user_id)
+    amount: Column[UInt64]
+
+
+class MissingColumn(Schema):
+    """Has a column that doesn't exist in Users."""
+
+    id: Column[UInt64]
+    email: Column[Utf8]
+
+
+class ExtraCheck(Schema):
+    """Only one column — 'name' and 'age' would be extra."""
+
+    id: Column[UInt64]
+
+
+# ---------------------------------------------------------------------------
+# _MappedFrom and mapped_from()
+# ---------------------------------------------------------------------------
+
+
+class TestMappedFrom:
+    def test_mapped_from_returns_mapped_from_instance(self) -> None:
+        result = mapped_from(Users.name)
+        assert isinstance(result, _MappedFrom)
+
+    def test_mapped_from_stores_source(self) -> None:
+        result = mapped_from(Users.name)
+        assert isinstance(result, _MappedFrom)
+        assert result.source is Users.name
+
+    def test_schema_with_mapped_from_has_mapped_from_on_column(self) -> None:
+        assert RenamedUsers.user_id._mapped_from is Users.id
+        assert RenamedUsers.user_name._mapped_from is Users.name
+
+    def test_schema_without_mapped_from_has_none(self) -> None:
+        assert Users.id._mapped_from is None
+        assert Users.name._mapped_from is None
+        assert Users.age._mapped_from is None
+
+    def test_mixed_schema_mapped_from(self) -> None:
+        assert MixedMapping.id._mapped_from is None
+        assert MixedMapping.user_name._mapped_from is Users.name
+
+
+# ---------------------------------------------------------------------------
+# SchemaError
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaError:
+    def test_missing_columns_attribute(self) -> None:
+        err = SchemaError(missing_columns=["email", "phone"])
+        assert err.missing_columns == ["email", "phone"]
+
+    def test_extra_columns_attribute(self) -> None:
+        err = SchemaError(extra_columns=["age", "name"])
+        assert err.extra_columns == ["age", "name"]
+
+    def test_type_mismatches_attribute(self) -> None:
+        err = SchemaError(type_mismatches={"age": ("UInt64", "Utf8")})
+        assert err.type_mismatches == {"age": ("UInt64", "Utf8")}
+
+    def test_null_violations_attribute(self) -> None:
+        err = SchemaError(null_violations=["name"])
+        assert err.null_violations == ["name"]
+
+    def test_message_contains_missing(self) -> None:
+        err = SchemaError(missing_columns=["email"])
+        assert "Missing columns" in str(err)
+        assert "email" in str(err)
+
+    def test_message_contains_extra(self) -> None:
+        err = SchemaError(extra_columns=["age"])
+        assert "Extra columns" in str(err)
+        assert "age" in str(err)
+
+    def test_default_message(self) -> None:
+        err = SchemaError()
+        assert "Schema validation failed" in str(err)
+
+    def test_is_exception(self) -> None:
+        assert issubclass(SchemaError, Exception)
+
+
+# ---------------------------------------------------------------------------
+# DataFrame.cast_schema — name matching
+# ---------------------------------------------------------------------------
+
+
+class TestCastSchemaNameMatching:
+    def setup_method(self) -> None:
+        self.df: DataFrame[Users] = DataFrame(_schema=Users)
+
+    def test_name_match_succeeds(self) -> None:
+        result = self.df.cast_schema(UsersSummary)
+        assert isinstance(result, DataFrame)
+        assert result._schema is UsersSummary
+
+    def test_missing_column_raises(self) -> None:
+        with pytest.raises(SchemaError) as exc_info:
+            self.df.cast_schema(MissingColumn)
+        assert "email" in exc_info.value.missing_columns
+
+    def test_extra_columns_drop_succeeds(self) -> None:
+        result = self.df.cast_schema(ExtraCheck, extra="drop")
+        assert isinstance(result, DataFrame)
+        assert result._schema is ExtraCheck
+
+    def test_extra_columns_forbid_raises(self) -> None:
+        with pytest.raises(SchemaError) as exc_info:
+            self.df.cast_schema(ExtraCheck, extra="forbid")
+        assert "name" in exc_info.value.extra_columns
+        assert "age" in exc_info.value.extra_columns
+
+
+# ---------------------------------------------------------------------------
+# DataFrame.cast_schema — mapped_from
+# ---------------------------------------------------------------------------
+
+
+class TestCastSchemaMappedFrom:
+    def setup_method(self) -> None:
+        self.df: DataFrame[Users] = DataFrame(_schema=Users)
+
+    def test_mapped_from_resolves(self) -> None:
+        result = self.df.cast_schema(RenamedUsers)
+        assert isinstance(result, DataFrame)
+        assert result._schema is RenamedUsers
+
+    def test_mixed_mapped_from_and_name_match(self) -> None:
+        result = self.df.cast_schema(MixedMapping)
+        assert isinstance(result, DataFrame)
+        assert result._schema is MixedMapping
+
+
+# ---------------------------------------------------------------------------
+# DataFrame.cast_schema — explicit mapping
+# ---------------------------------------------------------------------------
+
+
+class TestCastSchemaExplicitMapping:
+    def setup_method(self) -> None:
+        self.df: DataFrame[Users] = DataFrame(_schema=Users)
+
+    def test_explicit_mapping_resolves(self) -> None:
+        result = self.df.cast_schema(
+            MissingColumn,
+            mapping={MissingColumn.email: Users.name},
+        )
+        assert isinstance(result, DataFrame)
+        assert result._schema is MissingColumn
+
+    def test_explicit_mapping_overrides_mapped_from(self) -> None:
+        # Override RenamedUsers.user_id (mapped_from Users.id) to point at Users.age
+        result = self.df.cast_schema(
+            RenamedUsers,
+            mapping={RenamedUsers.user_id: Users.age},
+        )
+        assert isinstance(result, DataFrame)
+        assert result._schema is RenamedUsers
+
+
+# ---------------------------------------------------------------------------
+# cast_schema on JoinedDataFrame
+# ---------------------------------------------------------------------------
+
+
+class TestCastSchemaOnJoined:
+    def setup_method(self) -> None:
+        self.joined = JoinedDataFrame(_schema_left=Users, _schema_right=Orders)
+
+    def test_name_match_across_both_schemas(self) -> None:
+        result = self.joined.cast_schema(JoinTarget)
+        assert isinstance(result, DataFrame)
+        assert result._schema is JoinTarget
+
+    def test_ambiguous_name_without_mapping_raises(self) -> None:
+        """'id' exists in both Users and Orders — should be ambiguous."""
+
+        class AmbiguousTarget(Schema):
+            id: Column[UInt64]
+
+        with pytest.raises(SchemaError) as exc_info:
+            self.joined.cast_schema(AmbiguousTarget)
+        assert "id" in exc_info.value.missing_columns
+
+    def test_ambiguous_name_with_explicit_mapping_succeeds(self) -> None:
+        class AmbiguousTarget(Schema):
+            id: Column[UInt64]
+
+        result = self.joined.cast_schema(
+            AmbiguousTarget,
+            mapping={AmbiguousTarget.id: Users.id},
+        )
+        assert isinstance(result, DataFrame)
+        assert result._schema is AmbiguousTarget
+
+    def test_ambiguous_name_with_mapped_from_succeeds(self) -> None:
+        class AmbiguousResolved(Schema):
+            id: Column[UInt64] = mapped_from(Users.id)
+
+        result = self.joined.cast_schema(AmbiguousResolved)
+        assert isinstance(result, DataFrame)
+        assert result._schema is AmbiguousResolved
+
+    def test_returns_dataframe_not_joined(self) -> None:
+        result = self.joined.cast_schema(JoinTarget)
+        assert isinstance(result, DataFrame)
+        assert not isinstance(result, JoinedDataFrame)
+
+
+# ---------------------------------------------------------------------------
+# cast_schema on LazyFrame
+# ---------------------------------------------------------------------------
+
+
+class TestCastSchemaOnLazy:
+    def test_lazyframe_cast_schema_returns_lazyframe(self) -> None:
+        lf: LazyFrame[Users] = LazyFrame(_schema=Users)
+        result = lf.cast_schema(UsersSummary)
+        assert isinstance(result, LazyFrame)
+        assert result._schema is UsersSummary
+
+    def test_joined_lazyframe_cast_schema_returns_lazyframe(self) -> None:
+        jlf = JoinedLazyFrame(_schema_left=Users, _schema_right=Orders)
+        result = jlf.cast_schema(JoinTarget)
+        assert isinstance(result, LazyFrame)
+        assert result._schema is JoinTarget
+
+    def test_joined_lazyframe_not_joined_after_cast(self) -> None:
+        jlf = JoinedLazyFrame(_schema_left=Users, _schema_right=Orders)
+        result = jlf.cast_schema(JoinTarget)
+        assert not isinstance(result, JoinedLazyFrame)
+
+
+# ---------------------------------------------------------------------------
+# cast_schema on untyped (None schema) DataFrame
+# ---------------------------------------------------------------------------
+
+
+class TestCastSchemaOnUntyped:
+    def test_none_schema_skips_validation(self) -> None:
+        """DataFrame[Any] from select() has _schema=None — cast_schema just sets schema."""
+        df: DataFrame[Users] = DataFrame(_schema=None)
+        result = df.cast_schema(UsersSummary)
+        assert isinstance(result, DataFrame)
+        assert result._schema is UsersSummary


### PR DESCRIPTION
## Summary
- Add `mapped_from()` field modifier and `_MappedFrom` sentinel for declaring column source mappings in target schemas
- Add `SchemaError` exception with structured error attributes (missing_columns, extra_columns, type_mismatches, null_violations)
- Add `cast_schema()` to all 4 frame types: DataFrame, LazyFrame, JoinedDataFrame (→ DataFrame), JoinedLazyFrame (→ LazyFrame)
- Add `_resolve_mapping()` helper with 3-level resolution: explicit mapping → mapped_from → name match
- Add `Column.__hash__` to restore hashability after `__eq__` override (needed for mapping dict keys)
- Handle ambiguous column names in joined schemas (require explicit mapping or mapped_from)

Closes #8

## Test plan
- [x] 30 new unit tests covering mapped_from, SchemaError, cast_schema name matching, mapped_from resolution, explicit mapping, joined schemas, lazy frames, and untyped DataFrames
- [x] 10 typing tests (8 positive + 2 negative regression guards) verified by ty
- [x] All 294 tests pass
- [x] ruff check, ruff format, ty check all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)