### PR TITLE
Add PyPI publishing workflow and package metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Build colnade
+        run: uv build
+
+      - name: Build colnade-polars
+        run: uv build --package colnade-polars
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-colnade:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish colnade to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+
+  publish-colnade-polars:
+    needs: publish-colnade
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish colnade-polars to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 jwde
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/colnade-polars/README.md
+++ b/colnade-polars/README.md
@@ -1,0 +1,25 @@
+# colnade-polars
+
+Polars backend adapter for [Colnade](https://pypi.org/project/colnade/) — a statically type-safe DataFrame abstraction layer for Python.
+
+## Installation
+
+```bash
+pip install colnade colnade-polars
+```
+
+## Usage
+
+```python
+from colnade import Column, Schema, UInt64, Utf8
+from colnade_polars import read_parquet
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+
+df = read_parquet("users.parquet", Users)
+# df is DataFrame[Users] — fully type-checked
+```
+
+See the [full documentation](https://colnade.com/) for details.

--- a/colnade-polars/pyproject.toml
+++ b/colnade-polars/pyproject.toml
@@ -4,10 +4,31 @@ version = "0.1.0"
 description = "Polars backend adapter for Colnade"
 requires-python = ">=3.10"
 license = "MIT"
+readme = "README.md"
+authors = [
+    { name = "jwde" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+    "Topic :: Software Development :: Libraries",
+]
 dependencies = [
     "colnade>=0.1.0",
     "polars>=0.20",
 ]
+
+[project.urls]
+Homepage = "https://colnade.com"
+Documentation = "https://colnade.com"
+Repository = "https://github.com/jwde/colnade"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,31 @@ version = "0.1.0"
 description = "A statically type-safe DataFrame abstraction layer"
 requires-python = ">=3.10"
 license = "MIT"
+readme = "README.md"
+authors = [
+    { name = "jwde" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+    "Topic :: Software Development :: Libraries",
+]
 dependencies = [
     "typing_extensions>=4.0",
 ]
+
+[project.urls]
+Homepage = "https://colnade.com"
+Documentation = "https://colnade.com"
+Repository = "https://github.com/jwde/colnade"
+Issues = "https://github.com/jwde/colnade/issues"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary

- Add full PyPI metadata to both `pyproject.toml` files (authors, classifiers, readme, urls)
- Add MIT `LICENSE` file
- Add `colnade-polars/README.md` for its PyPI listing
- Add `.github/workflows/publish.yml` — builds both packages and publishes via trusted publishing (OIDC) on GitHub Release

## Setup required on PyPI

After merge, configure **trusted publishers** on [pypi.org](https://pypi.org/manage/account/publishing/):

| Package | Owner | Repository | Workflow | Environment |
|---------|-------|------------|----------|-------------|
| `colnade` | `jwde` | `colnade` | `publish.yml` | `pypi` |
| `colnade-polars` | `jwde` | `colnade` | `publish.yml` | `pypi` |

Also create a `pypi` environment in repo **Settings > Environments**.

## To publish

1. Create a GitHub Release (e.g. tag `v0.1.0`)
2. The workflow builds both packages and publishes them to PyPI automatically

## Test plan

- [x] `uv build` succeeds for colnade
- [x] `uv build --package colnade-polars` succeeds
- [x] 566 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)