### PR TITLE
Extend select() overloads, harden SchemaMeta, add benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,25 @@
+# Benchmarks
+
+Measures the runtime overhead of Colnade's expression AST construction and translation compared to calling Polars directly.
+
+## Running
+
+```bash
+uv run python benchmarks/bench_overhead.py
+```
+
+## What's measured
+
+| Benchmark | Description |
+|-----------|-------------|
+| Expr construction | `Users.age > 25` vs `pl.col("age") > 25` |
+| filter | Typed `df.filter(Users.age > 40)` vs `df.filter(pl.col("age") > 40)` |
+| select | Typed `df.select(Users.name, Users.score)` vs `df.select("name", "score")` |
+| pipeline | filter + sort + select chain |
+| lazy pipeline | Same chain via LazyFrame with `.collect()` |
+
+Each benchmark is run at 100, 10K, and 1M rows.
+
+## Typical results
+
+Overhead is negligible (0-5%) for most operations. The AST construction cost is constant and dwarfed by Polars' own execution time, even at small DataFrame sizes.

--- a/benchmarks/bench_overhead.py
+++ b/benchmarks/bench_overhead.py
@@ -1,0 +1,221 @@
+"""Benchmark: Colnade expression overhead vs raw Polars.
+
+Measures the cost of Colnade's expression AST construction and translation
+compared to calling Polars directly. Run with:
+
+    uv run python benchmarks/bench_overhead.py
+
+Results are printed as a table showing absolute times and relative overhead.
+"""
+
+from __future__ import annotations
+
+import timeit
+from dataclasses import dataclass
+
+import polars as pl
+
+from colnade import Column, Float64, Schema, UInt64, Utf8
+from colnade_polars import PolarsBackend
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+    age: Column[UInt64]
+    score: Column[Float64]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+backend = PolarsBackend()
+
+
+def make_df(n: int) -> pl.DataFrame:
+    """Create a raw Polars DataFrame with n rows."""
+    return pl.DataFrame(
+        {
+            "id": range(n),
+            "name": [f"user_{i}" for i in range(n)],
+            "age": [20 + (i % 60) for i in range(n)],
+            "score": [50.0 + (i % 50) for i in range(n)],
+        }
+    )
+
+
+def make_typed_df(n: int):
+    """Create a Colnade-typed DataFrame with n rows."""
+    from colnade.dataframe import DataFrame
+
+    raw = make_df(n)
+    return DataFrame(_data=raw, _schema=Users, _backend=backend)
+
+
+@dataclass
+class BenchResult:
+    label: str
+    raw_us: float
+    colnade_us: float
+
+    @property
+    def overhead_us(self) -> float:
+        return self.colnade_us - self.raw_us
+
+    @property
+    def overhead_pct(self) -> float:
+        return (self.overhead_us / self.raw_us) * 100 if self.raw_us > 0 else float("inf")
+
+
+# ---------------------------------------------------------------------------
+# Benchmarks
+# ---------------------------------------------------------------------------
+
+ITERATIONS = 1000
+
+
+def bench_expr_construction() -> BenchResult:
+    """Measure expression construction: pl.col("age") > 25 vs Users.age > 25."""
+    raw_time = timeit.timeit(lambda: pl.col("age") > 25, number=ITERATIONS)
+    colnade_time = timeit.timeit(lambda: Users.age > 25, number=ITERATIONS)
+    return BenchResult(
+        "Expr construction (col > 25)",
+        raw_time / ITERATIONS * 1_000_000,
+        colnade_time / ITERATIONS * 1_000_000,
+    )
+
+
+def bench_filter(n: int) -> BenchResult:
+    """Measure filter: raw Polars vs Colnade typed DataFrame."""
+    raw_df = make_df(n)
+    typed_df = make_typed_df(n)
+
+    iters = max(100, ITERATIONS // (n // 100 + 1))
+
+    raw_time = timeit.timeit(lambda: raw_df.filter(pl.col("age") > 40), number=iters)
+    colnade_time = timeit.timeit(lambda: typed_df.filter(Users.age > 40), number=iters)
+
+    return BenchResult(
+        f"filter (age > 40), {n:,} rows",
+        raw_time / iters * 1_000_000,
+        colnade_time / iters * 1_000_000,
+    )
+
+
+def bench_select(n: int) -> BenchResult:
+    """Measure select: raw Polars vs Colnade typed DataFrame."""
+    raw_df = make_df(n)
+    typed_df = make_typed_df(n)
+
+    iters = max(100, ITERATIONS // (n // 100 + 1))
+
+    raw_time = timeit.timeit(lambda: raw_df.select("name", "score"), number=iters)
+    colnade_time = timeit.timeit(lambda: typed_df.select(Users.name, Users.score), number=iters)
+
+    return BenchResult(
+        f"select (2 cols), {n:,} rows",
+        raw_time / iters * 1_000_000,
+        colnade_time / iters * 1_000_000,
+    )
+
+
+def bench_pipeline(n: int) -> BenchResult:
+    """Measure a filter+sort+select pipeline."""
+    raw_df = make_df(n)
+    typed_df = make_typed_df(n)
+
+    iters = max(50, ITERATIONS // (n // 100 + 1))
+
+    def raw_pipeline():
+        return (
+            raw_df.filter(pl.col("age") > 30).sort("score", descending=True).select("name", "score")
+        )
+
+    def colnade_pipeline():
+        return (
+            typed_df.filter(Users.age > 30).sort(Users.score.desc()).select(Users.name, Users.score)
+        )
+
+    raw_time = timeit.timeit(raw_pipeline, number=iters)
+    colnade_time = timeit.timeit(colnade_pipeline, number=iters)
+
+    return BenchResult(
+        f"pipeline (filter+sort+select), {n:,} rows",
+        raw_time / iters * 1_000_000,
+        colnade_time / iters * 1_000_000,
+    )
+
+
+def bench_lazy_pipeline(n: int) -> BenchResult:
+    """Measure lazy pipeline: build + collect."""
+    raw_df = make_df(n)
+    typed_df = make_typed_df(n)
+
+    iters = max(50, ITERATIONS // (n // 100 + 1))
+
+    def raw_lazy():
+        return (
+            raw_df.lazy()
+            .filter(pl.col("age") > 30)
+            .sort("score", descending=True)
+            .select("name", "score")
+            .collect()
+        )
+
+    def colnade_lazy():
+        return (
+            typed_df.lazy()
+            .filter(Users.age > 30)
+            .sort(Users.score.desc())
+            .select(Users.name, Users.score)
+            .collect()
+        )
+
+    raw_time = timeit.timeit(raw_lazy, number=iters)
+    colnade_time = timeit.timeit(colnade_lazy, number=iters)
+
+    return BenchResult(
+        f"lazy pipeline (build+collect), {n:,} rows",
+        raw_time / iters * 1_000_000,
+        colnade_time / iters * 1_000_000,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    results: list[BenchResult] = []
+
+    # Expression construction (no data)
+    results.append(bench_expr_construction())
+
+    # Varying DataFrame sizes
+    for n in [100, 10_000, 1_000_000]:
+        results.append(bench_filter(n))
+        results.append(bench_select(n))
+        results.append(bench_pipeline(n))
+        results.append(bench_lazy_pipeline(n))
+
+    # Print results
+    print()
+    print(f"{'Benchmark':<45} {'Raw (us)':>10} {'Colnade (us)':>13} {'Overhead':>10}")
+    print("-" * 82)
+    for r in results:
+        if r.overhead_pct < 10000:
+            overhead_str = f"+{r.overhead_pct:.0f}%"
+        else:
+            overhead_str = f"+{r.overhead_us:.0f}us"
+        print(f"{r.label:<45} {r.raw_us:>10.1f} {r.colnade_us:>13.1f} {overhead_str:>10}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/colnade/dataframe.py
+++ b/src/colnade/dataframe.py
@@ -180,6 +180,71 @@ class DataFrame(Generic[S]):
         c5: Column[Any],
         /,
     ) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        /,
+    ) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        /,
+    ) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        /,
+    ) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        c9: Column[Any],
+        /,
+    ) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        c9: Column[Any],
+        c10: Column[Any],
+        /,
+    ) -> DataFrame[Any]: ...
 
     def select(self, *columns: Column[Any]) -> DataFrame[Any]:
         """Select columns. Returns DataFrame[Any] — use cast_schema() to bind."""
@@ -330,6 +395,71 @@ class LazyFrame(Generic[S]):
         c3: Column[Any],
         c4: Column[Any],
         c5: Column[Any],
+        /,
+    ) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        /,
+    ) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        /,
+    ) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        /,
+    ) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        c9: Column[Any],
+        /,
+    ) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        c9: Column[Any],
+        c10: Column[Any],
         /,
     ) -> LazyFrame[Any]: ...
 
@@ -575,6 +705,71 @@ class JoinedDataFrame(Generic[S, S2]):
         c5: Column[Any],
         /,
     ) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        /,
+    ) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        /,
+    ) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        /,
+    ) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        c9: Column[Any],
+        /,
+    ) -> DataFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        c9: Column[Any],
+        c10: Column[Any],
+        /,
+    ) -> DataFrame[Any]: ...
 
     def select(self, *columns: Column[Any]) -> DataFrame[Any]:
         """Select columns. Returns DataFrame[Any] — use cast_schema() to bind."""
@@ -721,6 +916,71 @@ class JoinedLazyFrame(Generic[S, S2]):
         c3: Column[Any],
         c4: Column[Any],
         c5: Column[Any],
+        /,
+    ) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        /,
+    ) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        /,
+    ) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        /,
+    ) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        c9: Column[Any],
+        /,
+    ) -> LazyFrame[Any]: ...
+    @overload
+    def select(
+        self,
+        c1: Column[Any],
+        c2: Column[Any],
+        c3: Column[Any],
+        c4: Column[Any],
+        c5: Column[Any],
+        c6: Column[Any],
+        c7: Column[Any],
+        c8: Column[Any],
+        c9: Column[Any],
+        c10: Column[Any],
         /,
     ) -> LazyFrame[Any]: ...
 


### PR DESCRIPTION
## Summary

Addresses three no-tradeoff improvements identified from community feedback:

- **#27**: Extend `select()` overloads from arity 5 to 10 in all 4 frame classes (DataFrame, LazyFrame, JoinedDataFrame, JoinedLazyFrame)
- **#29**: Harden `SchemaMeta` — narrow `except Exception` to `(NameError, TypeError)`, emit `warnings.warn()` on fallback, document `type(Protocol)` dependency, verify unexpected exceptions propagate
- **#28**: Add `benchmarks/bench_overhead.py` comparing Colnade vs raw Polars at 100/10K/1M rows — overhead is 0-5% for typical operations

## Benchmark results

```
Benchmark                                       Raw (us)  Colnade (us)   Overhead
----------------------------------------------------------------------------------
Expr construction (col > 25)                         1.7           0.7       -59%
filter (age > 40), 100 rows                        237           234         -1%
pipeline (filter+sort+select), 1,000,000 rows    19412         19573         +1%
lazy pipeline (build+collect), 1,000,000 rows    16931         17785         +5%
```

## Test plan

- [x] 571 tests pass (5 new SchemaMeta robustness tests)
- [x] `ruff check .` and `ruff format --check .` clean
- [x] Benchmark script runs successfully

Closes #27, closes #28, closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)