### PR TITLE
Implement PyArrow boundary support: to_batches, from_batches

### DIFF
--- a/colnade-polars/pyproject.toml
+++ b/colnade-polars/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
     "colnade>=0.1.0",
     "polars>=0.20",
+    "pyarrow>=12.0",
 ]
 
 [project.urls]

--- a/src/colnade/__init__.py
+++ b/src/colnade/__init__.py
@@ -1,6 +1,7 @@
 """Colnade: A statically type-safe DataFrame abstraction layer."""
 
 from colnade._protocols import BackendProtocol
+from colnade.arrow import ArrowBatch
 from colnade.dataframe import (
     DataFrame,
     GroupBy,
@@ -56,6 +57,8 @@ from colnade.schema import Column, ListAccessor, Schema, SchemaError, mapped_fro
 __all__ = [
     # Backend
     "BackendProtocol",
+    # Arrow boundary
+    "ArrowBatch",
     # Schema layer
     "Schema",
     "Column",

--- a/src/colnade/_protocols.py
+++ b/src/colnade/_protocols.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
@@ -73,3 +73,17 @@ class BackendProtocol(Protocol):
     # --- Validation ---
 
     def validate_schema(self, source: Any, schema: type[Schema]) -> None: ...
+
+    # --- Arrow boundary ---
+
+    def to_arrow_batches(
+        self,
+        source: Any,
+        batch_size: int | None,
+    ) -> Iterator[Any]: ...
+
+    def from_arrow_batches(
+        self,
+        batches: Iterator[Any],
+        schema: type[Schema],
+    ) -> Any: ...

--- a/src/colnade/arrow.py
+++ b/src/colnade/arrow.py
@@ -1,0 +1,83 @@
+"""Typed Arrow batch wrapper for cross-framework boundaries.
+
+ArrowBatch[S] wraps a pyarrow.RecordBatch while preserving the schema type
+parameter, enabling type-safe data transfer between backends.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generic
+
+from colnade.schema import S, Schema, SchemaError
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+
+class ArrowBatch(Generic[S]):
+    """A typed wrapper around a pyarrow.RecordBatch.
+
+    Preserves the schema type parameter S across Arrow serialization
+    boundaries, so that type checkers can verify schema consistency
+    when data moves between backends.
+    """
+
+    __slots__ = ("_batch", "_schema")
+
+    def __init__(
+        self,
+        *,
+        _batch: Any,
+        _schema: type[S],
+    ) -> None:
+        self._batch = _batch
+        self._schema = _schema
+
+    def __repr__(self) -> str:
+        schema_name = self._schema.__name__ if self._schema else "Any"
+        n_rows = self._batch.num_rows if self._batch is not None else 0
+        return f"ArrowBatch[{schema_name}]({n_rows} rows)"
+
+    def to_pyarrow(self) -> pa.RecordBatch:
+        """Return the underlying pyarrow.RecordBatch."""
+        return self._batch
+
+    @classmethod
+    def from_pyarrow(
+        cls,
+        batch: pa.RecordBatch,
+        schema: type[S],
+    ) -> ArrowBatch[S]:
+        """Wrap a pyarrow.RecordBatch with schema validation.
+
+        Checks that the Arrow batch's column names match the schema.
+        Raises :class:`SchemaError` on missing columns.
+        """
+        _validate_arrow_schema(batch.schema, schema)
+        return cls(_batch=batch, _schema=schema)
+
+    @property
+    def num_rows(self) -> int:
+        """Number of rows in this batch."""
+        return self._batch.num_rows
+
+    @property
+    def schema(self) -> type[S]:
+        """The Colnade schema type."""
+        return self._schema
+
+
+def _validate_arrow_schema(
+    arrow_schema: Any,
+    colnade_schema: type[Schema],
+) -> None:
+    """Validate that an Arrow schema's columns match a Colnade schema.
+
+    Checks column names are present. Type validation is left to backends
+    since Arrow-to-Colnade dtype mapping is backend-specific.
+    """
+    arrow_names = set(arrow_schema.names) if arrow_schema is not None else set()
+    expected = colnade_schema._columns
+    missing = [name for name in expected if name not in arrow_names]
+    if missing:
+        raise SchemaError(missing_columns=missing)

--- a/tests/integration/test_arrow_boundary.py
+++ b/tests/integration/test_arrow_boundary.py
@@ -1,0 +1,176 @@
+"""Integration tests for Arrow boundary (to_batches / from_batches)."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from colnade import ArrowBatch, Column, DataFrame, Schema, UInt64, Utf8
+from colnade_polars.adapter import PolarsBackend
+
+pa = pytest.importorskip("pyarrow")
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+
+
+def _users_df() -> DataFrame[Users]:
+    data = pl.DataFrame(
+        {
+            "id": pl.Series([1, 2, 3], dtype=pl.UInt64),
+            "name": ["Alice", "Bob", "Charlie"],
+        }
+    )
+    return DataFrame(_data=data, _schema=Users, _backend=PolarsBackend())
+
+
+# ---------------------------------------------------------------------------
+# to_batches
+# ---------------------------------------------------------------------------
+
+
+class TestToBatches:
+    def test_returns_arrow_batches(self) -> None:
+        df = _users_df()
+        batches = list(df.to_batches())
+        assert len(batches) >= 1
+        assert all(isinstance(b, ArrowBatch) for b in batches)
+
+    def test_preserves_schema_type(self) -> None:
+        df = _users_df()
+        batches = list(df.to_batches())
+        for batch in batches:
+            assert batch.schema is Users
+
+    def test_with_batch_size(self) -> None:
+        df = _users_df()
+        batches = list(df.to_batches(batch_size=2))
+        assert len(batches) == 2
+        assert batches[0].num_rows == 2
+        assert batches[1].num_rows == 1
+
+    def test_pyarrow_roundtrip(self) -> None:
+        df = _users_df()
+        batches = list(df.to_batches())
+        for batch in batches:
+            rb = batch.to_pyarrow()
+            assert isinstance(rb, pa.RecordBatch)
+            assert set(rb.schema.names) == {"id", "name"}
+
+    def test_no_backend_raises(self) -> None:
+        df: DataFrame[Users] = DataFrame(_schema=Users)
+        with pytest.raises(RuntimeError, match="requires a backend"):
+            list(df.to_batches())
+
+    def test_total_rows_match(self) -> None:
+        df = _users_df()
+        batches = list(df.to_batches())
+        total = sum(b.num_rows for b in batches)
+        assert total == 3
+
+    def test_batch_size_one(self) -> None:
+        df = _users_df()
+        batches = list(df.to_batches(batch_size=1))
+        assert len(batches) == 3
+        assert all(b.num_rows == 1 for b in batches)
+
+
+# ---------------------------------------------------------------------------
+# from_batches
+# ---------------------------------------------------------------------------
+
+
+class TestFromBatches:
+    def test_round_trip(self) -> None:
+        original = _users_df()
+        batches = list(original.to_batches())
+        restored = DataFrame.from_batches(iter(batches), Users, PolarsBackend())
+        assert restored._data.shape == (3, 2)
+        assert restored._data["name"].to_list() == ["Alice", "Bob", "Charlie"]
+        assert restored._data["id"].to_list() == [1, 2, 3]
+
+    def test_preserves_schema(self) -> None:
+        original = _users_df()
+        batches = list(original.to_batches())
+        restored = DataFrame.from_batches(iter(batches), Users, PolarsBackend())
+        assert restored._schema is Users
+
+    def test_preserves_backend(self) -> None:
+        backend = PolarsBackend()
+        original = _users_df()
+        batches = list(original.to_batches())
+        restored = DataFrame.from_batches(iter(batches), Users, backend)
+        assert restored._backend is backend
+
+    def test_multiple_batches(self) -> None:
+        original = _users_df()
+        batches = list(original.to_batches(batch_size=1))
+        assert len(batches) == 3
+        restored = DataFrame.from_batches(iter(batches), Users, PolarsBackend())
+        assert restored._data.shape == (3, 2)
+
+    def test_round_trip_data_integrity(self) -> None:
+        original = _users_df()
+        batches = list(original.to_batches(batch_size=2))
+        restored = DataFrame.from_batches(iter(batches), Users, PolarsBackend())
+        # Verify row-level data integrity
+        orig_rows = original._data.sort("id").to_dicts()
+        rest_rows = restored._data.sort("id").to_dicts()
+        assert orig_rows == rest_rows
+
+
+# ---------------------------------------------------------------------------
+# PolarsBackend Arrow methods directly
+# ---------------------------------------------------------------------------
+
+
+class TestPolarsBackendArrowMethods:
+    def test_to_arrow_batches_returns_record_batches(self) -> None:
+        backend = PolarsBackend()
+        data = pl.DataFrame(
+            {
+                "id": pl.Series([1, 2], dtype=pl.UInt64),
+                "name": ["a", "b"],
+            }
+        )
+        batches = list(backend.to_arrow_batches(data, None))
+        assert all(isinstance(b, pa.RecordBatch) for b in batches)
+
+    def test_to_arrow_batches_with_batch_size(self) -> None:
+        backend = PolarsBackend()
+        data = pl.DataFrame(
+            {
+                "id": pl.Series(list(range(10)), dtype=pl.UInt64),
+                "name": [f"u{i}" for i in range(10)],
+            }
+        )
+        batches = list(backend.to_arrow_batches(data, 3))
+        total = sum(b.num_rows for b in batches)
+        assert total == 10
+
+    def test_from_arrow_batches_returns_polars_df(self) -> None:
+        backend = PolarsBackend()
+        rb = pa.record_batch(
+            {"id": [1, 2], "name": ["a", "b"]},
+            schema=pa.schema([("id", pa.uint64()), ("name", pa.string())]),
+        )
+        result = backend.from_arrow_batches(iter([rb]), Users)
+        assert isinstance(result, pl.DataFrame)
+        assert result.shape == (2, 2)
+
+    def test_from_arrow_batches_empty(self) -> None:
+        backend = PolarsBackend()
+        result = backend.from_arrow_batches(iter([]), Users)
+        assert isinstance(result, pl.DataFrame)
+        assert result.shape == (0, 0)
+
+    def test_from_arrow_batches_multiple(self) -> None:
+        backend = PolarsBackend()
+        schema = pa.schema([("id", pa.uint64()), ("name", pa.string())])
+        rb1 = pa.record_batch({"id": [1], "name": ["a"]}, schema=schema)
+        rb2 = pa.record_batch({"id": [2], "name": ["b"]}, schema=schema)
+        result = backend.from_arrow_batches(iter([rb1, rb2]), Users)
+        assert isinstance(result, pl.DataFrame)
+        assert result.shape == (2, 2)

--- a/tests/unit/test_arrow.py
+++ b/tests/unit/test_arrow.py
@@ -1,0 +1,101 @@
+"""Unit tests for ArrowBatch[S] typed wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from colnade import ArrowBatch, Column, Schema, SchemaError, UInt64, Utf8
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+
+
+# ---------------------------------------------------------------------------
+# Construction and basic properties
+# ---------------------------------------------------------------------------
+
+
+class TestArrowBatchConstruction:
+    def test_init_stores_batch_and_schema(self) -> None:
+        sentinel = object()
+        batch = ArrowBatch(_batch=sentinel, _schema=Users)
+        assert batch._batch is sentinel
+        assert batch._schema is Users
+
+    def test_repr_includes_schema_name(self) -> None:
+        class FakeBatch:
+            num_rows = 42
+
+        batch = ArrowBatch(_batch=FakeBatch(), _schema=Users)
+        r = repr(batch)
+        assert "Users" in r
+        assert "42" in r
+
+    def test_to_pyarrow_returns_inner(self) -> None:
+        sentinel = object()
+        batch = ArrowBatch(_batch=sentinel, _schema=Users)
+        assert batch.to_pyarrow() is sentinel
+
+    def test_schema_property(self) -> None:
+        batch = ArrowBatch(_batch=None, _schema=Users)
+        assert batch.schema is Users
+
+
+# ---------------------------------------------------------------------------
+# from_pyarrow (requires pyarrow)
+# ---------------------------------------------------------------------------
+
+
+class TestArrowBatchFromPyarrow:
+    @pytest.fixture(autouse=True)
+    def _skip_no_pyarrow(self) -> None:
+        pytest.importorskip("pyarrow")
+
+    def test_from_pyarrow_valid(self) -> None:
+        import pyarrow as pa
+
+        rb = pa.record_batch(
+            {"id": [1, 2], "name": ["Alice", "Bob"]},
+            schema=pa.schema([("id", pa.uint64()), ("name", pa.string())]),
+        )
+        batch = ArrowBatch.from_pyarrow(rb, Users)
+        assert batch.num_rows == 2
+        assert batch.schema is Users
+
+    def test_from_pyarrow_missing_column_raises(self) -> None:
+        import pyarrow as pa
+
+        rb = pa.record_batch(
+            {"id": [1, 2]},
+            schema=pa.schema([("id", pa.uint64())]),
+        )
+        with pytest.raises(SchemaError):
+            ArrowBatch.from_pyarrow(rb, Users)
+
+    def test_from_pyarrow_extra_columns_ok(self) -> None:
+        import pyarrow as pa
+
+        rb = pa.record_batch(
+            {"id": [1], "name": ["Alice"], "extra": [99]},
+            schema=pa.schema(
+                [
+                    ("id", pa.uint64()),
+                    ("name", pa.string()),
+                    ("extra", pa.int64()),
+                ]
+            ),
+        )
+        batch = ArrowBatch.from_pyarrow(rb, Users)
+        assert batch.num_rows == 1
+
+    def test_num_rows_property(self) -> None:
+        import pyarrow as pa
+
+        rb = pa.record_batch(
+            {"id": [1, 2, 3], "name": ["a", "b", "c"]},
+            schema=pa.schema([("id", pa.uint64()), ("name", pa.string())]),
+        )
+        batch = ArrowBatch.from_pyarrow(rb, Users)
+        assert batch.num_rows == 3

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -238,12 +238,12 @@ class TestConversion:
         result = df.validate()
         assert result is df
 
-    def test_to_batches_not_implemented(self) -> None:
+    def test_to_batches_no_backend_raises(self) -> None:
         import pytest
 
         df: DataFrame[Users] = DataFrame(_schema=Users)
-        with pytest.raises(NotImplementedError):
-            df.to_batches()
+        with pytest.raises(RuntimeError, match="requires a backend"):
+            list(df.to_batches())
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -183,12 +183,14 @@ source = { editable = "colnade-polars" }
 dependencies = [
     { name = "colnade" },
     { name = "polars" },
+    { name = "pyarrow" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "colnade", editable = "." },
     { name = "polars", specifier = ">=0.20" },
+    { name = "pyarrow", specifier = ">=12.0" },
 ]
 
 [[package]]
@@ -698,6 +700,63 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/f3/b2a5e720cc56eaa38b4518e63aa577b4bbd60e8b05a00fe43ca051be5879/polars_runtime_32-1.38.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61e8d73c614b46a00d2f853625a7569a2e4a0999333e876354ac81d1bf1bb5e2", size = 45336615 },
     { url = "https://files.pythonhosted.org/packages/f1/8d/ee2e4b7de948090cfb3df37d401c521233daf97bfc54ddec5d61d1d31618/polars_runtime_32-1.38.1-cp310-abi3-win_amd64.whl", hash = "sha256:08c2b3b93509c1141ac97891294ff5c5b0c548a373f583eaaea873a4bf506437", size = 45680732 },
     { url = "https://files.pythonhosted.org/packages/bf/18/72c216f4ab0c82b907009668f79183ae029116ff0dd245d56ef58aac48e7/polars_runtime_32-1.38.1-cp310-abi3-win_arm64.whl", hash = "sha256:6d07d0cc832bfe4fb54b6e04218c2c27afcfa6b9498f9f6bbf262a00d58cc7c4", size = 41639413 },
+]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/33/ffd9c3eb087fa41dd79c3cf20c4c0ae3cdb877c4f8e1107a446006344924/pyarrow-23.0.0.tar.gz", hash = "sha256:180e3150e7edfcd182d3d9afba72f7cf19839a497cc76555a8dce998a8f67615", size = 1167185 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/2f/23e042a5aa99bcb15e794e14030e8d065e00827e846e53a66faec73c7cd6/pyarrow-23.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:cbdc2bf5947aa4d462adcf8453cf04aee2f7932653cb67a27acd96e5e8528a67", size = 34281861 },
+    { url = "https://files.pythonhosted.org/packages/8b/65/1651933f504b335ec9cd8f99463718421eb08d883ed84f0abd2835a16cad/pyarrow-23.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:4d38c836930ce15cd31dce20114b21ba082da231c884bdc0a7b53e1477fe7f07", size = 35825067 },
+    { url = "https://files.pythonhosted.org/packages/84/ec/d6fceaec050c893f4e35c0556b77d4cc9973fcc24b0a358a5781b1234582/pyarrow-23.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4222ff8f76919ecf6c716175a0e5fddb5599faeed4c56d9ea41a2c42be4998b2", size = 44458539 },
+    { url = "https://files.pythonhosted.org/packages/fd/d9/369f134d652b21db62fe3ec1c5c2357e695f79eb67394b8a93f3a2b2cffa/pyarrow-23.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:87f06159cbe38125852657716889296c83c37b4d09a5e58f3d10245fd1f69795", size = 47535889 },
+    { url = "https://files.pythonhosted.org/packages/a3/95/f37b6a252fdbf247a67a78fb3f61a529fe0600e304c4d07741763d3522b1/pyarrow-23.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1675c374570d8b91ea6d4edd4608fa55951acd44e0c31bd146e091b4005de24f", size = 48157777 },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/fb94923108c9c6415dab677cf1f066d3307798eafc03f9a65ab4abc61056/pyarrow-23.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:247374428fde4f668f138b04031a7e7077ba5fa0b5b1722fdf89a017bf0b7ee0", size = 50580441 },
+    { url = "https://files.pythonhosted.org/packages/ae/78/897ba6337b517fc8e914891e1bd918da1c4eb8e936a553e95862e67b80f6/pyarrow-23.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:de53b1bd3b88a2ee93c9af412c903e57e738c083be4f6392288294513cd8b2c1", size = 27530028 },
+    { url = "https://files.pythonhosted.org/packages/aa/c0/57fe251102ca834fee0ef69a84ad33cc0ff9d5dfc50f50b466846356ecd7/pyarrow-23.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:5574d541923efcbfdf1294a2746ae3b8c2498a2dc6cd477882f6f4e7b1ac08d3", size = 34276762 },
+    { url = "https://files.pythonhosted.org/packages/f8/4e/24130286548a5bc250cbed0b6bbf289a2775378a6e0e6f086ae8c68fc098/pyarrow-23.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:2ef0075c2488932e9d3c2eb3482f9459c4be629aa673b725d5e3cf18f777f8e4", size = 35821420 },
+    { url = "https://files.pythonhosted.org/packages/ee/55/a869e8529d487aa2e842d6c8865eb1e2c9ec33ce2786eb91104d2c3e3f10/pyarrow-23.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:65666fc269669af1ef1c14478c52222a2aa5c907f28b68fb50a203c777e4f60c", size = 44457412 },
+    { url = "https://files.pythonhosted.org/packages/36/81/1de4f0edfa9a483bbdf0082a05790bd6a20ed2169ea12a65039753be3a01/pyarrow-23.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:4d85cb6177198f3812db4788e394b757223f60d9a9f5ad6634b3e32be1525803", size = 47534285 },
+    { url = "https://files.pythonhosted.org/packages/f2/04/464a052d673b5ece074518f27377861662449f3c1fdb39ce740d646fd098/pyarrow-23.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1a9ff6fa4141c24a03a1a434c63c8fa97ce70f8f36bccabc18ebba905ddf0f17", size = 48157913 },
+    { url = "https://files.pythonhosted.org/packages/f4/1b/32a4de9856ee6688c670ca2def588382e573cce45241a965af04c2f61687/pyarrow-23.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:84839d060a54ae734eb60a756aeacb62885244aaa282f3c968f5972ecc7b1ecc", size = 50582529 },
+    { url = "https://files.pythonhosted.org/packages/db/c7/d6581f03e9b9e44ea60b52d1750ee1a7678c484c06f939f45365a45f7eef/pyarrow-23.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:a149a647dbfe928ce8830a713612aa0b16e22c64feac9d1761529778e4d4eaa5", size = 27542646 },
+    { url = "https://files.pythonhosted.org/packages/3d/bd/c861d020831ee57609b73ea721a617985ece817684dc82415b0bc3e03ac3/pyarrow-23.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5961a9f646c232697c24f54d3419e69b4261ba8a8b66b0ac54a1851faffcbab8", size = 34189116 },
+    { url = "https://files.pythonhosted.org/packages/8c/23/7725ad6cdcbaf6346221391e7b3eecd113684c805b0a95f32014e6fa0736/pyarrow-23.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:632b3e7c3d232f41d64e1a4a043fb82d44f8a349f339a1188c6a0dd9d2d47d8a", size = 35803831 },
+    { url = "https://files.pythonhosted.org/packages/57/06/684a421543455cdc2944d6a0c2cc3425b028a4c6b90e34b35580c4899743/pyarrow-23.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:76242c846db1411f1d6c2cc3823be6b86b40567ee24493344f8226ba34a81333", size = 44436452 },
+    { url = "https://files.pythonhosted.org/packages/c6/6f/8f9eb40c2328d66e8b097777ddcf38494115ff9f1b5bc9754ba46991191e/pyarrow-23.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b73519f8b52ae28127000986bf228fda781e81d3095cd2d3ece76eb5cf760e1b", size = 47557396 },
+    { url = "https://files.pythonhosted.org/packages/10/6e/f08075f1472e5159553501fde2cc7bc6700944bdabe49a03f8a035ee6ccd/pyarrow-23.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:068701f6823449b1b6469120f399a1239766b117d211c5d2519d4ed5861f75de", size = 48147129 },
+    { url = "https://files.pythonhosted.org/packages/7d/82/d5a680cd507deed62d141cc7f07f7944a6766fc51019f7f118e4d8ad0fb8/pyarrow-23.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1801ba947015d10e23bca9dd6ef5d0e9064a81569a89b6e9a63b59224fd060df", size = 50596642 },
+    { url = "https://files.pythonhosted.org/packages/a9/26/4f29c61b3dce9fa7780303b86895ec6a0917c9af927101daaaf118fbe462/pyarrow-23.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:52265266201ec25b6839bf6bd4ea918ca6d50f31d13e1cf200b4261cd11dc25c", size = 27660628 },
+    { url = "https://files.pythonhosted.org/packages/66/34/564db447d083ec7ff93e0a883a597d2f214e552823bfc178a2d0b1f2c257/pyarrow-23.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:ad96a597547af7827342ffb3c503c8316e5043bb09b47a84885ce39394c96e00", size = 34184630 },
+    { url = "https://files.pythonhosted.org/packages/aa/3a/3999daebcb5e6119690c92a621c4d78eef2ffba7a0a1b56386d2875fcd77/pyarrow-23.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:b9edf990df77c2901e79608f08c13fbde60202334a4fcadb15c1f57bf7afee43", size = 35796820 },
+    { url = "https://files.pythonhosted.org/packages/ec/ee/39195233056c6a8d0976d7d1ac1cd4fe21fb0ec534eca76bc23ef3f60e11/pyarrow-23.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:36d1b5bc6ddcaff0083ceec7e2561ed61a51f49cce8be079ee8ed406acb6fdef", size = 44438735 },
+    { url = "https://files.pythonhosted.org/packages/2c/41/6a7328ee493527e7afc0c88d105ecca69a3580e29f2faaeac29308369fd7/pyarrow-23.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4292b889cd224f403304ddda8b63a36e60f92911f89927ec8d98021845ea21be", size = 47557263 },
+    { url = "https://files.pythonhosted.org/packages/c6/ee/34e95b21ee84db494eae60083ddb4383477b31fb1fd19fd866d794881696/pyarrow-23.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:dfd9e133e60eaa847fd80530a1b89a052f09f695d0b9c34c235ea6b2e0924cf7", size = 48153529 },
+    { url = "https://files.pythonhosted.org/packages/52/88/8a8d83cea30f4563efa1b7bf51d241331ee5cd1b185a7e063f5634eca415/pyarrow-23.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:832141cc09fac6aab1cd3719951d23301396968de87080c57c9a7634e0ecd068", size = 50598851 },
+    { url = "https://files.pythonhosted.org/packages/c6/4c/2929c4be88723ba025e7b3453047dc67e491c9422965c141d24bab6b5962/pyarrow-23.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:7a7d067c9a88faca655c71bcc30ee2782038d59c802d57950826a07f60d83c4c", size = 27577747 },
+    { url = "https://files.pythonhosted.org/packages/64/52/564a61b0b82d72bd68ec3aef1adda1e3eba776f89134b9ebcb5af4b13cb6/pyarrow-23.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:ce9486e0535a843cf85d990e2ec5820a47918235183a5c7b8b97ed7e92c2d47d", size = 34446038 },
+    { url = "https://files.pythonhosted.org/packages/cc/c9/232d4f9855fd1de0067c8a7808a363230d223c83aeee75e0fe6eab851ba9/pyarrow-23.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:075c29aeaa685fd1182992a9ed2499c66f084ee54eea47da3eb76e125e06064c", size = 35921142 },
+    { url = "https://files.pythonhosted.org/packages/96/f2/60af606a3748367b906bb82d41f0032e059f075444445d47e32a7ff1df62/pyarrow-23.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:799965a5379589510d888be3094c2296efd186a17ca1cef5b77703d4d5121f53", size = 44490374 },
+    { url = "https://files.pythonhosted.org/packages/ff/2d/7731543050a678ea3a413955a2d5d80d2a642f270aa57a3cb7d5a86e3f46/pyarrow-23.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ef7cac8fe6fccd8b9e7617bfac785b0371a7fe26af59463074e4882747145d40", size = 47527896 },
+    { url = "https://files.pythonhosted.org/packages/5a/90/f3342553b7ac9879413aed46500f1637296f3c8222107523a43a1c08b42a/pyarrow-23.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15a414f710dc927132dd67c361f78c194447479555af57317066ee5116b90e9e", size = 48210401 },
+    { url = "https://files.pythonhosted.org/packages/f3/da/9862ade205ecc46c172b6ce5038a74b5151c7401e36255f15975a45878b2/pyarrow-23.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e0d2e6915eca7d786be6a77bf227fbc06d825a75b5b5fe9bcbef121dec32685", size = 50579677 },
+    { url = "https://files.pythonhosted.org/packages/c2/4c/f11f371f5d4740a5dafc2e11c76bcf42d03dfdb2d68696da97de420b6963/pyarrow-23.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:4b317ea6e800b5704e5e5929acb6e2dc13e9276b708ea97a39eb8b345aa2658b", size = 27631889 },
+    { url = "https://files.pythonhosted.org/packages/97/bb/15aec78bcf43a0c004067bd33eb5352836a29a49db8581fc56f2b6ca88b7/pyarrow-23.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:20b187ed9550d233a872074159f765f52f9d92973191cd4b93f293a19efbe377", size = 34213265 },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/deb2c594bbba41c37c5d9aa82f510376998352aa69dfcb886cb4b18ad80f/pyarrow-23.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:18ec84e839b493c3886b9b5e06861962ab4adfaeb79b81c76afbd8d84c7d5fda", size = 35819211 },
+    { url = "https://files.pythonhosted.org/packages/e0/e5/ee82af693cb7b5b2b74f6524cdfede0e6ace779d7720ebca24d68b57c36b/pyarrow-23.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e438dd3f33894e34fd02b26bd12a32d30d006f5852315f611aa4add6c7fab4bc", size = 44502313 },
+    { url = "https://files.pythonhosted.org/packages/9c/86/95c61ad82236495f3c31987e85135926ba3ec7f3819296b70a68d8066b49/pyarrow-23.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:a244279f240c81f135631be91146d7fa0e9e840e1dfed2aba8483eba25cd98e6", size = 47585886 },
+    { url = "https://files.pythonhosted.org/packages/bb/6e/a72d901f305201802f016d015de1e05def7706fff68a1dedefef5dc7eff7/pyarrow-23.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c4692e83e42438dba512a570c6eaa42be2f8b6c0f492aea27dec54bdc495103a", size = 48207055 },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/5de029c537630ca18828db45c30e2a78da03675a70ac6c3528203c416fe3/pyarrow-23.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae7f30f898dfe44ea69654a35c93e8da4cef6606dc4c72394068fd95f8e9f54a", size = 50619812 },
+    { url = "https://files.pythonhosted.org/packages/59/8d/2af846cd2412e67a087f5bda4a8e23dfd4ebd570f777db2e8686615dafc1/pyarrow-23.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:5b86bb649e4112fb0614294b7d0a175c7513738876b89655605ebb87c804f861", size = 28263851 },
+    { url = "https://files.pythonhosted.org/packages/7b/7f/caab863e587041156f6786c52e64151b7386742c8c27140f637176e9230e/pyarrow-23.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ebc017d765d71d80a3f8584ca0566b53e40464586585ac64176115baa0ada7d3", size = 34463240 },
+    { url = "https://files.pythonhosted.org/packages/c9/fa/3a5b8c86c958e83622b40865e11af0857c48ec763c11d472c87cd518283d/pyarrow-23.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:0800cc58a6d17d159df823f87ad66cefebf105b982493d4bad03ee7fab84b993", size = 35935712 },
+    { url = "https://files.pythonhosted.org/packages/c5/08/17a62078fc1a53decb34a9aa79cf9009efc74d63d2422e5ade9fed2f99e3/pyarrow-23.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:3a7c68c722da9bb5b0f8c10e3eae71d9825a4b429b40b32709df5d1fa55beb3d", size = 44503523 },
+    { url = "https://files.pythonhosted.org/packages/cc/70/84d45c74341e798aae0323d33b7c39194e23b1abc439ceaf60a68a7a969a/pyarrow-23.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:bd5556c24622df90551063ea41f559b714aa63ca953db884cfb958559087a14e", size = 47542490 },
+    { url = "https://files.pythonhosted.org/packages/61/d9/d1274b0e6f19e235de17441e53224f4716574b2ca837022d55702f24d71d/pyarrow-23.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54810f6e6afc4ffee7c2e0051b61722fbea9a4961b46192dcfae8ea12fa09059", size = 48233605 },
+    { url = "https://files.pythonhosted.org/packages/39/07/e4e2d568cb57543d84482f61e510732820cddb0f47c4bb7df629abfed852/pyarrow-23.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:14de7d48052cf4b0ed174533eafa3cfe0711b8076ad70bede32cf59f744f0d7c", size = 50603979 },
+    { url = "https://files.pythonhosted.org/packages/72/9c/47693463894b610f8439b2e970b82ef81e9599c757bf2049365e40ff963c/pyarrow-23.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:427deac1f535830a744a4f04a6ac183a64fcac4341b3f618e693c41b7b98d2b0", size = 28338905 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **`ArrowBatch[S]`** — typed wrapper around `pa.RecordBatch` that preserves schema type parameter across Arrow boundaries (`src/colnade/arrow.py`)
- **`DataFrame.to_batches(batch_size)`** — converts to `Iterator[ArrowBatch[S]]` via backend delegation
- **`DataFrame.from_batches(batches, schema, backend)`** — classmethod to reconstruct typed DataFrame from Arrow batches
- **`BackendProtocol`** — adds `to_arrow_batches` and `from_arrow_batches` methods
- **`PolarsBackend`** — implements Arrow methods using `df.to_arrow()` and `pl.from_arrow()`
- **`pyarrow>=12.0`** added as explicit dependency of `colnade-polars` only

**No pyarrow dependency on the core `colnade` package.** The core defines `ArrowBatch[S]` as a generic wrapper that imports pyarrow only inside `TYPE_CHECKING` for annotations. The actual pyarrow runtime usage is isolated to the `colnade-polars` adapter.

## Test plan

- [x] 596 tests pass (25 new: unit + integration)
- [x] `ruff check .` and `ruff format --check .` clean
- [x] `ty check tests/typing/ --error-on-warning` clean
- [x] Round-trip verified: `to_batches` → `from_batches` preserves data, schema, and backend

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)