### PR TITLE
Replace ASCII architecture diagram with Mermaid

### DIFF
--- a/docs/user-guide/core-concepts.md
+++ b/docs/user-guide/core-concepts.md
@@ -4,25 +4,39 @@ Colnade is organized into four layers. Understanding these layers helps you use 
 
 ## Architecture
 
-```
-┌──────────────────────────────────────────────────────┐
-│                    User Code                         │
-│  (schemas, transforms, pipeline definitions)         │
-├──────────────────────────────────────────────────────┤
-│              colnade (core library)                  │
-│  ┌────────────┐  ┌──────────────┐  ┌──────────────┐ │
-│  │   Schema    │  │  Expression  │  │  DataFrame   │ │
-│  │   Layer     │  │    DSL       │  │  Interface   │ │
-│  └────────────┘  └──────────────┘  └──────────────┘ │
-├──────────────────────────────────────────────────────┤
-│                 Backend Adapters                      │
-│  ┌────────┐ ┌──────────┐ ┌─────┐ ┌────────────────┐ │
-│  │ Polars │ │ Snowpark │ │ Ray │ │ DuckDB / etc.  │ │
-│  └────────┘ └──────────┘ └─────┘ └────────────────┘ │
-├──────────────────────────────────────────────────────┤
-│              Execution Engines                        │
-│  (Polars, Snowflake, Ray Data, DuckDB, etc.)         │
-└──────────────────────────────────────────────────────┘
+```mermaid
+block-beta
+  columns 4
+
+  block:user:4
+    columns 4
+    A["User Code<br/><i>schemas, transforms, pipelines</i>"]:4
+  end
+
+  space:4
+
+  block:core:4
+    columns 3
+    B["Schema Layer"] C["Expression DSL"] D["DataFrame Interface"]
+  end
+
+  space:4
+
+  block:adapters:4
+    columns 4
+    E["Polars"] F["Pandas"] G["DuckDB"] H["Spark"]
+  end
+
+  space:4
+
+  block:engines:4
+    columns 4
+    I["Execution Engines<br/><i>Polars, Pandas, DuckDB, Spark, etc.</i>"]:4
+  end
+
+  user --> core
+  core --> adapters
+  adapters --> engines
 ```
 
 ## Schema Layer

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,11 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - admonition


### PR DESCRIPTION
## Summary

- Replace misaligned ASCII box-drawing architecture diagram with a Mermaid block diagram that renders as a proper SVG
- Enable Mermaid support in mkdocs.yml via `pymdownx.superfences` custom fence
- Also updated the adapter names to reflect the current roadmap (Polars, Pandas, DuckDB, Spark)

## Test plan

- [x] `mkdocs build` succeeds
- [x] Mermaid block present in rendered HTML
- [x] No remaining ASCII diagrams in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)