### PR TITLE
Shrink architecture diagram to compact flowchart

### DIFF
--- a/docs/user-guide/core-concepts.md
+++ b/docs/user-guide/core-concepts.md
@@ -5,38 +5,17 @@ Colnade is organized into four layers. Understanding these layers helps you use 
 ## Architecture
 
 ```mermaid
-block-beta
-  columns 4
-
-  block:user:4
-    columns 4
-    A["User Code<br/><i>schemas, transforms, pipelines</i>"]:4
-  end
-
-  space:4
-
-  block:core:4
-    columns 3
-    B["Schema Layer"] C["Expression DSL"] D["DataFrame Interface"]
-  end
-
-  space:4
-
-  block:adapters:4
-    columns 4
-    E["Polars"] F["Pandas"] G["DuckDB"] H["Spark"]
-  end
-
-  space:4
-
-  block:engines:4
-    columns 4
-    I["Execution Engines<br/><i>Polars, Pandas, DuckDB, Spark, etc.</i>"]:4
-  end
-
-  user --> core
-  core --> adapters
-  adapters --> engines
+graph TD
+  A["User Code"] --> B["Schema Layer"]
+  A --> C["Expression DSL"]
+  A --> D["DataFrame Interface"]
+  B --> E["Backend Adapters"]
+  C --> E
+  D --> E
+  E --> F["Polars"]
+  E --> G["Pandas"]
+  E --> H["DuckDB"]
+  E --> I["Spark"]
 ```
 
 ## Schema Layer


### PR DESCRIPTION
## Summary
- Replace oversized `block-beta` Mermaid diagram with a compact `graph TD` flowchart
- Same layered architecture, drastically less vertical space

## Test plan
- [ ] Preview on docs site — diagram should fit comfortably in one viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)