### PR TITLE
Add rich repr and _repr_html_ to Schema classes

### DIFF
--- a/src/colnade/schema.py
+++ b/src/colnade/schema.py
@@ -608,6 +608,29 @@ class SchemaMeta(type(Protocol)):  # type(Protocol) is typing._ProtocolMeta (CPy
 
         return cls
 
+    @staticmethod
+    def _dtype_name(dtype: Any) -> str:
+        if hasattr(dtype, "__name__"):
+            return dtype.__name__
+        return str(dtype)
+
+    def __repr__(cls) -> str:
+        columns = getattr(cls, "_columns", {})
+        if not columns:
+            return cls.__name__
+        cols = ", ".join(f"{c.name}: {SchemaMeta._dtype_name(c.dtype)}" for c in columns.values())
+        return f"{cls.__name__}({cols})"
+
+    def _repr_html_(cls) -> str:
+        columns = getattr(cls, "_columns", {})
+        if not columns:
+            return f"<b>{cls.__name__}</b>"
+        rows = "".join(
+            f"<tr><td>{c.name}</td><td>{SchemaMeta._dtype_name(c.dtype)}</td></tr>"
+            for c in columns.values()
+        )
+        return f"<b>{cls.__name__}</b><table><tr><th>Column</th><th>Type</th></tr>{rows}</table>"
+
 
 # ---------------------------------------------------------------------------
 # Schema base class

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -285,3 +285,34 @@ class TestSchemaMetaRobustness:
                 raise AssertionError("RuntimeError should have propagated")
             except RuntimeError:
                 pass  # Expected
+
+
+# ---------------------------------------------------------------------------
+# Schema repr
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaRepr:
+    def test_repr_with_columns(self) -> None:
+        r = repr(Users)
+        assert r.startswith("Users(")
+        assert "id: UInt64" in r
+        assert "name: Utf8" in r
+
+    def test_repr_empty_schema(self) -> None:
+        assert repr(Empty) == "Empty"
+
+    def test_repr_html_with_columns(self) -> None:
+        html = Users._repr_html_()
+        assert "<b>Users</b>" in html
+        assert "<th>Column</th>" in html
+        assert "<td>id</td>" in html
+        assert "<td>UInt64</td>" in html
+
+    def test_repr_html_empty_schema(self) -> None:
+        assert Empty._repr_html_() == "<b>Empty</b>"
+
+    def test_repr_inherited_schema(self) -> None:
+        r = repr(EnrichedUsers)
+        assert "normalized_age: Float64" in r
+        assert "id: UInt64" in r


### PR DESCRIPTION
## Summary
- `__repr__` on Schema classes now shows column names and types: `Users(id: UInt64, name: Utf8, age: UInt8 | None)`
- `_repr_html_()` renders an HTML table in Jupyter with Column/Type headers
- Handles nullable union types (`UInt8 | None`) gracefully

Closes #47

## Test plan
- [x] 5 new unit tests covering repr, html, empty schema, and inherited schemas
- [x] Full suite passes (619 tests)
- [ ] Verify in a Jupyter notebook that `Users` renders a nice table

🤖 Generated with [Claude Code](https://claude.com/claude-code)