### PR TITLE
Add CLAUDE.md with pre-commit check rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# Colnade Development Rules
+
+## Before Every Commit
+
+You MUST run the following checks before committing and ensure they all pass:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest tests/ -v
+uv run ty check tests/typing/ --error-on-warning
+```
+
+If any check fails, fix the issue before committing. Do not commit with known failures.


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` requiring all linter, formatter, test, and type checks to pass before every commit

## Test plan
- [x] All checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)