### PR TITLE
Add CI check for API docs coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
       - run: uv sync
+      - run: uv run python scripts/check_api_docs.py
       - run: uv run mkdocs build --strict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,15 @@ uv run ruff check .
 uv run ruff format --check .
 uv run pytest tests/ -v
 uv run ty check tests/typing/ --error-on-warning
+uv run python scripts/check_api_docs.py
 ```
 
 If any check fails, fix the issue before committing. Do not commit with known failures.
+
+## Updating Documentation
+
+When you add, remove, or rename any public API symbol (anything in `__all__`):
+
+1. **API reference** (auto-generated) — Add/update/remove the `::: module.Symbol` directive in the appropriate `docs/api/*.md` file. Run `uv run python scripts/check_api_docs.py` to verify coverage.
+2. **User guide** (manual) — Update the relevant page in `docs/user-guide/` to document new features or reflect removed ones.
+3. **Tutorials** (manual) — Update any affected tutorials in `docs/tutorials/` if they reference changed APIs.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,7 +4,7 @@
 
 | Module | Description |
 |--------|-------------|
-| [`colnade.schema`](schema.md) | Schema base class, Column descriptors, mapped_from, SchemaError |
+| [`colnade core`](schema.md) | Schema, Column, BackendProtocol, ArrowBatch, validation utilities |
 | [`colnade.dataframe`](dataframe.md) | DataFrame, LazyFrame, GroupBy, JoinedDataFrame, Untyped frames |
 | [`colnade.expr`](expressions.md) | Expression AST nodes (ColumnRef, BinOp, Agg, etc.) |
 | [`colnade.dtypes`](types.md) | Data type definitions (UInt64, Float64, Utf8, Struct, List, etc.) |

--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -1,6 +1,6 @@
-# colnade.schema
+# colnade core
 
-Schema base class, Column descriptors, and supporting utilities.
+Schema base class, Column descriptors, backend protocol, and supporting utilities.
 
 ## Schema
 
@@ -29,3 +29,19 @@ Schema base class, Column descriptors, and supporting utilities.
 ::: colnade.schema.SchemaMeta
     options:
       members: false
+
+## BackendProtocol
+
+::: colnade._protocols.BackendProtocol
+
+## ArrowBatch
+
+::: colnade.arrow.ArrowBatch
+
+## set_validation
+
+::: colnade.validation.set_validation
+
+## is_validation_enabled
+
+::: colnade.validation.is_validation_enabled

--- a/docs/user-guide/dataframes.md
+++ b/docs/user-guide/dataframes.md
@@ -100,7 +100,7 @@ Validate that data conforms to the schema:
 df.validate()  # raises SchemaError on mismatch
 ```
 
-Checks column existence and data types. See [Validation](validation.md) for the global toggle and auto-validation at IO boundaries.
+Checks column existence and data types. Enable auto-validation at data boundaries with `COLNADE_VALIDATE=1` or `colnade.set_validation(True)`.
 
 ## What Colnade validates
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,7 @@ nav:
       - Full Pipeline: tutorials/full-pipeline.md
   - API Reference:
       - Overview: api/index.md
-      - colnade.schema: api/schema.md
+      - colnade core: api/schema.md
       - colnade.dataframe: api/dataframe.md
       - colnade.expr: api/expressions.md
       - colnade.dtypes: api/types.md

--- a/scripts/check_api_docs.py
+++ b/scripts/check_api_docs.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Verify every public export in __all__ has a ::: directive in the API docs.
+
+Usage:
+    uv run python scripts/check_api_docs.py
+
+Exits 0 if all exports are documented, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+DOCS_API_DIR = Path(__file__).resolve().parent.parent / "docs" / "api"
+DIRECTIVE_RE = re.compile(r"^:::\ +(\S+)", re.MULTILINE)
+
+PACKAGES: dict[str, str] = {
+    "colnade": "src/colnade/__init__.py",
+    "colnade_polars": "colnade-polars/src/colnade_polars/__init__.py",
+}
+
+
+def _collect_documented_symbols() -> set[str]:
+    """Scan docs/api/*.md for ::: directives and return the set of documented paths."""
+    documented: set[str] = set()
+    for md_file in DOCS_API_DIR.glob("*.md"):
+        text = md_file.read_text()
+        for match in DIRECTIVE_RE.finditer(text):
+            documented.add(match.group(1))
+    return documented
+
+
+def _resolve_symbol_path(package_name: str, symbol_name: str, symbol: object) -> str:
+    """Resolve a symbol to its full module.qualname path for matching ::: directives."""
+    module = getattr(symbol, "__module__", None)
+    qualname = getattr(symbol, "__qualname__", symbol_name)
+    if module:
+        return f"{module}.{qualname}"
+    return f"{package_name}.{symbol_name}"
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(root / "src"))
+    sys.path.insert(0, str(root / "colnade-polars" / "src"))
+
+    missing: list[tuple[str, str]] = []
+
+    for package_name, _init_path in PACKAGES.items():
+        mod = __import__(package_name)
+        all_exports: list[str] = getattr(mod, "__all__", [])
+
+        documented = _collect_documented_symbols()
+
+        for name in all_exports:
+            symbol = getattr(mod, name, None)
+            if symbol is None:
+                missing.append((package_name, f"{package_name}.{name} (not importable)"))
+                continue
+
+            path = _resolve_symbol_path(package_name, name, symbol)
+            if path not in documented:
+                missing.append((package_name, path))
+
+    if missing:
+        print("API docs coverage check FAILED.\n")
+        print("The following public exports are missing ::: directives in docs/api/*.md:\n")
+        for pkg, path in missing:
+            print(f"  - {path}  (from {pkg}.__all__)")
+        print("\nAdd a '::: <path>' directive to the appropriate docs/api/*.md file.")
+        return 1
+
+    print("API docs coverage check passed. All exports documented.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds `scripts/check_api_docs.py` that verifies every `__all__` export from `colnade` and `colnade_polars` has a `::: ` directive in `docs/api/*.md`
- Integrates the check into the CI `docs` job (runs before `mkdocs build --strict`)
- Updates `CLAUDE.md` with the check in pre-commit list and a new "Updating Documentation" section reminding to update API references + manual docs
- Fixes 4 missing API doc entries (`BackendProtocol`, `ArrowBatch`, `set_validation`, `is_validation_enabled`)
- Fixes pre-existing broken `[Validation](validation.md)` link in dataframes docs

## Test plan
- [x] `uv run python scripts/check_api_docs.py` passes (all exports documented)
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run pytest tests/ -v` — 679 tests pass
- [x] `uv run ty check tests/typing/ --error-on-warning` passes
- [x] `uv run mkdocs build --strict` passes

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)