### PR TITLE
Add Dask backend adapter (colnade-dask)

### DIFF
--- a/colnade-dask/README.md
+++ b/colnade-dask/README.md
@@ -1,0 +1,3 @@
+# colnade-dask
+
+Dask backend adapter for [Colnade](https://github.com/jwde/colnade).

--- a/colnade-dask/pyproject.toml
+++ b/colnade-dask/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "colnade-dask"
+version = "0.1.0"
+description = "Dask backend adapter for Colnade"
+requires-python = ">=3.10"
+license = "MIT"
+readme = "README.md"
+authors = [
+    { name = "jwde" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "colnade>=0.2.0",
+    "colnade-pandas>=0.1.0",
+    "dask[dataframe]>=2024.1",
+    "pyarrow>=12.0",
+]
+
+[project.urls]
+Homepage = "https://colnade.com"
+Documentation = "https://colnade.com"
+Repository = "https://github.com/jwde/colnade"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/colnade_dask"]

--- a/colnade-dask/src/colnade_dask/__init__.py
+++ b/colnade-dask/src/colnade_dask/__init__.py
@@ -1,0 +1,21 @@
+"""Colnade Dask backend adapter."""
+
+from colnade_dask.adapter import DaskBackend
+from colnade_dask.io import (
+    read_csv,
+    read_parquet,
+    scan_csv,
+    scan_parquet,
+    write_csv,
+    write_parquet,
+)
+
+__all__ = [
+    "DaskBackend",
+    "read_csv",
+    "read_parquet",
+    "scan_csv",
+    "scan_parquet",
+    "write_csv",
+    "write_parquet",
+]

--- a/colnade-dask/src/colnade_dask/adapter.py
+++ b/colnade-dask/src/colnade_dask/adapter.py
@@ -1,0 +1,467 @@
+"""DaskBackend — translates Colnade expression trees and executes operations on Dask DataFrames."""
+
+from __future__ import annotations
+
+import types as _types
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+import dask.dataframe as dd
+import pandas as pd
+
+from colnade.expr import (
+    Agg,
+    AliasedExpr,
+    BinOp,
+    ColumnRef,
+    Expr,
+    FunctionCall,
+    ListOp,
+    Literal,
+    SortExpr,
+    StructFieldAccess,
+    UnaryOp,
+)
+from colnade.schema import Column, Schema, SchemaError
+from colnade_pandas.conversion import map_colnade_dtype, map_pandas_dtype
+
+# ---------------------------------------------------------------------------
+# BinOp operator dispatch
+# ---------------------------------------------------------------------------
+
+_BINOP_MAP: dict[str, str] = {
+    "+": "__add__",
+    "-": "__sub__",
+    "*": "__mul__",
+    "/": "__truediv__",
+    "%": "__mod__",
+    ">": "__gt__",
+    "<": "__lt__",
+    ">=": "__ge__",
+    "<=": "__le__",
+    "==": "__eq__",
+    "!=": "__ne__",
+    "&": "__and__",
+    "|": "__or__",
+}
+
+# ---------------------------------------------------------------------------
+# Agg function name mapping (Colnade → Pandas/Dask)
+# ---------------------------------------------------------------------------
+
+_AGG_MAP: dict[str, str] = {
+    "sum": "sum",
+    "mean": "mean",
+    "min": "min",
+    "max": "max",
+    "count": "count",
+    "first": "first",
+    "last": "last",
+}
+
+# ---------------------------------------------------------------------------
+# DaskBackend
+# ---------------------------------------------------------------------------
+
+
+class DaskBackend:
+    """Colnade backend adapter for Dask.
+
+    Expression translation produces callables ``(df) -> Series | scalar``
+    since Dask, like Pandas, has no standalone lazy expression API.  The
+    callables build lazy Dask task graphs instead of executing immediately.
+    """
+
+    # --- Expression translation ---
+
+    def translate_expr(self, expr: Expr[Any]) -> Any:
+        """Recursively translate a Colnade AST node to a callable (df -> result)."""
+        if isinstance(expr, AliasedExpr):
+            inner_fn = self.translate_expr(expr.expr)
+            target_name = expr.target.name
+            return (inner_fn, target_name)
+
+        if isinstance(expr, ColumnRef):
+            col_name = expr.column.name
+            return lambda df, _cn=col_name: df[_cn]
+
+        if isinstance(expr, Literal):
+            val = expr.value
+            return lambda df, _v=val: _v
+
+        if isinstance(expr, BinOp):
+            left_fn = self._ensure_callable(self.translate_expr(expr.left))
+            right_fn = self._ensure_callable(self.translate_expr(expr.right))
+            method = _BINOP_MAP.get(expr.op)
+            if method is None:
+                msg = f"Unsupported BinOp operator: {expr.op}"
+                raise ValueError(msg)
+            return lambda df, _l=left_fn, _r=right_fn, _m=method: getattr(_l(df), _m)(_r(df))
+
+        if isinstance(expr, UnaryOp):
+            operand_fn = self._ensure_callable(self.translate_expr(expr.operand))
+            if expr.op == "-":
+                return lambda df, _o=operand_fn: -_o(df)
+            if expr.op == "~":
+                return lambda df, _o=operand_fn: ~_o(df)
+            if expr.op == "is_null":
+                return lambda df, _o=operand_fn: _o(df).isna()
+            if expr.op == "is_not_null":
+                return lambda df, _o=operand_fn: _o(df).notna()
+            if expr.op == "is_nan":
+                return lambda df, _o=operand_fn: _o(df).isna()
+            msg = f"Unsupported UnaryOp: {expr.op}"
+            raise ValueError(msg)
+
+        if isinstance(expr, Agg):
+            source_fn = self._ensure_callable(self.translate_expr(expr.source))
+            agg_name = _AGG_MAP.get(expr.agg_type)
+            if agg_name is None:
+                msg = f"Unsupported aggregation: {expr.agg_type}"
+                raise ValueError(msg)
+            return (source_fn, agg_name)
+
+        if isinstance(expr, FunctionCall):
+            return self._translate_function_call(expr)
+
+        if isinstance(expr, StructFieldAccess):
+            struct_fn = self._ensure_callable(self.translate_expr(expr.struct_expr))
+            field_name = expr.field.name
+            return lambda df, _s=struct_fn, _f=field_name: _s(df).apply(lambda x: x.get(_f))
+
+        if isinstance(expr, ListOp):
+            return self._translate_list_op(expr)
+
+        msg = f"Unsupported expression type: {type(expr).__name__}"
+        raise TypeError(msg)
+
+    def _ensure_callable(self, translated: Any) -> Any:
+        """Unwrap (fn, alias) tuples from AliasedExpr to get the callable."""
+        if isinstance(translated, tuple):
+            return translated[0]
+        return translated
+
+    def _translate_function_call(self, expr: FunctionCall[Any]) -> Any:
+        """Translate a FunctionCall node to a Dask callable."""
+        name = expr.name
+
+        # String methods
+        if name == "str_contains":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            pattern = expr.args[1]
+            return lambda df, _s=source_fn, _p=pattern: _s(df).str.contains(_p, regex=False)
+        if name == "str_starts_with":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            pattern = expr.args[1]
+            return lambda df, _s=source_fn, _p=pattern: _s(df).str.startswith(_p)
+        if name == "str_ends_with":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            pattern = expr.args[1]
+            return lambda df, _s=source_fn, _p=pattern: _s(df).str.endswith(_p)
+        if name == "str_len":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            return lambda df, _s=source_fn: _s(df).str.len()
+        if name == "str_to_lowercase":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            return lambda df, _s=source_fn: _s(df).str.lower()
+        if name == "str_to_uppercase":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            return lambda df, _s=source_fn: _s(df).str.upper()
+        if name == "str_strip":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            return lambda df, _s=source_fn: _s(df).str.strip()
+        if name == "str_replace":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            old, new = expr.args[1], expr.args[2]
+            return lambda df, _s=source_fn, _o=old, _n=new: _s(df).str.replace(_o, _n, regex=False)
+
+        # Temporal methods
+        if name == "dt_year":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            return lambda df, _s=source_fn: _s(df).dt.year
+        if name == "dt_month":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            return lambda df, _s=source_fn: _s(df).dt.month
+        if name == "dt_day":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            return lambda df, _s=source_fn: _s(df).dt.day
+        if name == "dt_hour":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            return lambda df, _s=source_fn: _s(df).dt.hour
+        if name == "dt_minute":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            return lambda df, _s=source_fn: _s(df).dt.minute
+        if name == "dt_second":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            return lambda df, _s=source_fn: _s(df).dt.second
+        if name == "dt_truncate":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            unit = expr.args[1]
+            return lambda df, _s=source_fn, _u=unit: _s(df).dt.floor(_u)
+
+        # Null/NaN handling
+        if name == "fill_null":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            fill_fn = self._ensure_callable(self.translate_expr(expr.args[1]))
+            return lambda df, _s=source_fn, _f=fill_fn: _s(df).fillna(_f(df))
+        if name == "fill_nan":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            fill_fn = self._ensure_callable(self.translate_expr(expr.args[1]))
+            return lambda df, _s=source_fn, _f=fill_fn: _s(df).fillna(_f(df))
+        if name == "assert_non_null":
+            return self._ensure_callable(self.translate_expr(expr.args[0]))
+
+        # Cast
+        if name == "cast":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            target_dtype = map_colnade_dtype(expr.kwargs["dtype"])
+            return lambda df, _s=source_fn, _t=target_dtype: _s(df).astype(_t)
+
+        # Window function (over)
+        if name == "over":
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+            partition_names = [self._ensure_callable(self.translate_expr(a)) for a in expr.args[1:]]
+            return lambda df, _s=source_fn, _p=partition_names: df.groupby(
+                [p(df).name for p in _p]
+            )[_s(df).name].transform(lambda x: x)
+
+        msg = f"Unsupported FunctionCall: {name}"
+        raise ValueError(msg)
+
+    def _translate_list_op(self, expr: ListOp[Any]) -> Any:
+        """Translate a ListOp node to a Dask callable."""
+        list_fn = self._ensure_callable(self.translate_expr(expr.list_expr))
+        op = expr.op
+
+        if op == "len":
+            return lambda df, _l=list_fn: _l(df).apply(len)
+        if op == "get":
+            idx = expr.args[0]
+            return lambda df, _l=list_fn, _i=idx: _l(df).apply(lambda x: x[_i])
+        if op == "contains":
+            val = expr.args[0]
+            return lambda df, _l=list_fn, _v=val: _l(df).apply(lambda x: _v in x)
+        if op == "sum":
+            return lambda df, _l=list_fn: _l(df).apply(sum)
+        if op == "mean":
+            return lambda df, _l=list_fn: _l(df).apply(lambda x: sum(x) / len(x) if x else None)
+        if op == "min":
+            return lambda df, _l=list_fn: _l(df).apply(min)
+        if op == "max":
+            return lambda df, _l=list_fn: _l(df).apply(max)
+
+        msg = f"Unsupported ListOp: {op}"
+        raise ValueError(msg)
+
+    # --- Execution methods ---
+
+    def filter(self, source: Any, predicate: Expr[Any]) -> Any:
+        pred_fn = self._ensure_callable(self.translate_expr(predicate))
+        mask = pred_fn(source)
+        return source.loc[mask].reset_index(drop=True)
+
+    def sort(
+        self,
+        source: Any,
+        by: Sequence[Column[Any] | SortExpr],
+        descending: bool,
+    ) -> Any:
+        col_names: list[str] = []
+        ascending: list[bool] = []
+        for item in by:
+            if isinstance(item, SortExpr):
+                col_names.append(item.expr.column.name)
+                ascending.append(not item.descending)
+            else:
+                col_names.append(item.name)
+                ascending.append(not descending)
+        return source.sort_values(by=col_names, ascending=ascending).reset_index(drop=True)
+
+    def limit(self, source: Any, n: int) -> Any:
+        return source.head(n, npartitions=-1, compute=False)
+
+    def head(self, source: Any, n: int) -> Any:
+        return source.head(n, npartitions=-1, compute=False)
+
+    def tail(self, source: Any, n: int) -> Any:
+        # Dask tail() returns a Pandas DF — re-wrap in Dask
+        return dd.from_pandas(source.tail(n), npartitions=1)
+
+    def sample(self, source: Any, n: int) -> Any:
+        # Dask doesn't support sample(n=...), only sample(frac=...)
+        # Compute to Pandas, sample, and re-wrap
+        computed = source.compute()
+        sampled = computed.sample(n).reset_index(drop=True)
+        return dd.from_pandas(sampled, npartitions=1)
+
+    def unique(self, source: Any, columns: Sequence[Column[Any]]) -> Any:
+        return source.drop_duplicates(subset=[c.name for c in columns]).reset_index(drop=True)
+
+    def drop_nulls(self, source: Any, columns: Sequence[Column[Any]]) -> Any:
+        return source.dropna(subset=[c.name for c in columns]).reset_index(drop=True)
+
+    def with_columns(self, source: Any, exprs: Sequence[AliasedExpr[Any] | Expr[Any]]) -> Any:
+        result = source
+        for expr in exprs:
+            translated = self.translate_expr(expr)
+            if isinstance(translated, tuple):
+                fn, alias = translated
+                result = result.assign(**{alias: fn(result)})
+            else:
+                msg = "with_columns requires aliased expressions"
+                raise ValueError(msg)
+        return result
+
+    def select(self, source: Any, columns: Sequence[Column[Any]]) -> Any:
+        return source[[c.name for c in columns]]
+
+    def group_by_agg(
+        self,
+        source: Any,
+        keys: Sequence[Column[Any]],
+        aggs: Sequence[AliasedExpr[Any]],
+    ) -> Any:
+        key_names = [k.name for k in keys]
+        agg_dict: dict[str, str] = {}
+        rename_map: dict[str, str] = {}
+
+        for agg_expr in aggs:
+            translated = self.translate_expr(agg_expr)
+            if not isinstance(translated, tuple):
+                msg = "group_by_agg requires aliased aggregation expressions"
+                raise ValueError(msg)
+
+            inner, alias = translated
+            if isinstance(inner, tuple):
+                source_fn, agg_name = inner
+                col_name = self._extract_col_name(source_fn, source)
+                agg_dict[col_name] = agg_name
+                rename_map[col_name] = alias
+            else:
+                msg = "group_by_agg requires aggregation expressions (e.g., .sum(), .mean())"
+                raise ValueError(msg)
+
+        grouped = source.groupby(key_names).agg(agg_dict).reset_index()
+        for old_name, new_name in rename_map.items():
+            if old_name != new_name and old_name not in key_names:
+                grouped = grouped.rename(columns={old_name: new_name})
+        return grouped
+
+    def _extract_col_name(self, fn: Any, df: Any) -> str:
+        """Extract column name from a translated ColumnRef function."""
+        series = fn(df)
+        if hasattr(series, "name"):
+            return series.name
+        msg = "Cannot extract column name from expression"
+        raise ValueError(msg)
+
+    @staticmethod
+    def _dtypes_compatible(actual: Any, expected: Any) -> bool:
+        """Compare dtypes accounting for storage backend variations.
+
+        Dask may use different storage backends (e.g., pyarrow vs python)
+        for the same logical dtype, so strict equality can fail.
+        """
+        if actual == expected:
+            return True
+        # StringDtype with different storage backends (python vs pyarrow)
+        return isinstance(actual, pd.StringDtype) and isinstance(expected, pd.StringDtype)
+
+    def join(self, left: Any, right: Any, on: Any, how: str) -> Any:
+        return left.merge(right, left_on=on.left.name, right_on=on.right.name, how=how)
+
+    def cast_schema(self, source: Any, column_mapping: dict[str, str]) -> Any:
+        rename_map = {src: tgt for tgt, src in column_mapping.items()}
+        result = source.rename(columns=rename_map)
+        return result[list(column_mapping.keys())]
+
+    def lazy(self, source: Any) -> Any:
+        # Dask is inherently lazy — passthrough
+        return source
+
+    def collect(self, source: Any) -> Any:
+        # Materialize the Dask task graph and re-wrap so DaskBackend
+        # can continue operating on the result.
+        return dd.from_pandas(source.compute(), npartitions=1)
+
+    def validate_schema(self, source: Any, schema: type[Schema]) -> None:
+        """Validate that a Dask DataFrame matches the schema."""
+        expected_columns = schema._columns
+        actual_names = set(source.columns)
+
+        missing = [n for n in expected_columns if n not in actual_names]
+        type_mismatches: dict[str, tuple[str, str]] = {}
+
+        for col_name, col in expected_columns.items():
+            if col_name not in actual_names:
+                continue
+            actual_pd_dtype = source[col_name].dtype
+            expected_pd_dtype = map_colnade_dtype(col.dtype)
+            if not self._dtypes_compatible(actual_pd_dtype, expected_pd_dtype):
+                try:
+                    actual_colnade = map_pandas_dtype(actual_pd_dtype).__name__
+                except TypeError:
+                    actual_colnade = str(actual_pd_dtype)
+                expected_name = (
+                    col.dtype.__name__ if hasattr(col.dtype, "__name__") else str(col.dtype)
+                )
+                type_mismatches[col_name] = (expected_name, actual_colnade)
+
+        # Null checks require computation in Dask
+        null_violations: list[str] = []
+        for col_name, col in expected_columns.items():
+            if col_name not in actual_names:
+                continue
+            if isinstance(col.dtype, _types.UnionType):
+                continue
+            if source[col_name].isna().any().compute():
+                null_violations.append(col_name)
+
+        if missing or type_mismatches or null_violations:
+            raise SchemaError(
+                missing_columns=missing if missing else None,
+                type_mismatches=type_mismatches if type_mismatches else None,
+                null_violations=null_violations if null_violations else None,
+            )
+
+    # --- Introspection ---
+
+    def row_count(self, source: Any) -> int:
+        return len(source)
+
+    def iter_row_dicts(self, source: Any) -> Iterator[dict[str, Any]]:
+        return source.compute().to_dict(orient="records")
+
+    # --- Arrow boundary ---
+
+    def to_arrow_batches(
+        self,
+        source: Any,
+        batch_size: int | None,
+    ) -> Iterator[Any]:
+        """Convert a Dask DataFrame to an iterator of Arrow RecordBatches."""
+        import pyarrow as pa
+
+        # Iterate partitions for memory-efficient conversion
+        for partition in source.partitions:
+            pdf: pd.DataFrame = partition.compute()
+            table: pa.Table = pa.Table.from_pandas(pdf)
+            if batch_size is not None:
+                yield from table.to_batches(max_chunksize=batch_size)
+            else:
+                yield from table.to_batches()
+
+    def from_arrow_batches(
+        self,
+        batches: Iterator[Any],
+        schema: type[Any],
+    ) -> Any:
+        """Reconstruct a Dask DataFrame from Arrow RecordBatches."""
+        import pyarrow as pa
+
+        batch_list = list(batches)
+        if not batch_list:
+            return dd.from_pandas(pd.DataFrame(), npartitions=1)
+        table = pa.Table.from_batches(batch_list)
+        pdf = table.to_pandas()
+        return dd.from_pandas(pdf, npartitions=1)

--- a/colnade-dask/src/colnade_dask/io.py
+++ b/colnade-dask/src/colnade_dask/io.py
@@ -1,0 +1,69 @@
+"""Read/write operations for Dask backend."""
+
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+import dask.dataframe as dd
+
+from colnade import DataFrame, LazyFrame, Schema
+from colnade.validation import is_validation_enabled
+from colnade_dask.adapter import DaskBackend
+from colnade_pandas.conversion import map_colnade_dtype
+
+S = TypeVar("S", bound=Schema)
+
+
+def _build_pandas_schema(schema: type[S]) -> dict[str, Any]:
+    """Build a Pandas dtype dict from a Colnade schema."""
+    return {name: map_colnade_dtype(col.dtype) for name, col in schema._columns.items()}
+
+
+def read_parquet(path: str, schema: type[S], **kwargs: Any) -> DataFrame[S]:
+    """Read a Parquet file into a typed DataFrame backed by Dask."""
+    backend = DaskBackend()
+    data = dd.read_parquet(path, **kwargs)
+    if is_validation_enabled():
+        backend.validate_schema(data, schema)
+    return DataFrame(_data=data, _schema=schema, _backend=backend)
+
+
+def read_csv(path: str, schema: type[S], **kwargs: Any) -> DataFrame[S]:
+    """Read a CSV file into a typed DataFrame backed by Dask.
+
+    Applies the schema's dtype mapping to ensure correct column types.
+    """
+    backend = DaskBackend()
+    pd_schema = _build_pandas_schema(schema)
+    data = dd.read_csv(path, dtype=pd_schema, **kwargs)
+    if is_validation_enabled():
+        backend.validate_schema(data, schema)
+    return DataFrame(_data=data, _schema=schema, _backend=backend)
+
+
+def scan_parquet(path: str, schema: type[S], **kwargs: Any) -> LazyFrame[S]:
+    """Lazily scan a Parquet file into a typed LazyFrame backed by Dask."""
+    backend = DaskBackend()
+    data = dd.read_parquet(path, **kwargs)
+    return LazyFrame(_data=data, _schema=schema, _backend=backend)
+
+
+def scan_csv(path: str, schema: type[S], **kwargs: Any) -> LazyFrame[S]:
+    """Lazily scan a CSV file into a typed LazyFrame backed by Dask.
+
+    Applies the schema's dtype mapping to ensure correct column types.
+    """
+    backend = DaskBackend()
+    pd_schema = _build_pandas_schema(schema)
+    data = dd.read_csv(path, dtype=pd_schema, **kwargs)
+    return LazyFrame(_data=data, _schema=schema, _backend=backend)
+
+
+def write_parquet(df: DataFrame[Any], path: str, **kwargs: Any) -> None:
+    """Write a DataFrame to a Parquet file."""
+    df._data.to_parquet(path, **kwargs)
+
+
+def write_csv(df: DataFrame[Any], path: str, **kwargs: Any) -> None:
+    """Write a DataFrame to a CSV file."""
+    df._data.to_csv(path, index=False, single_file=True, **kwargs)

--- a/docs/api/dask.md
+++ b/docs/api/dask.md
@@ -1,0 +1,21 @@
+# colnade_dask
+
+Dask backend adapter, I/O functions, and scan functions.
+
+## DaskBackend
+
+::: colnade_dask.adapter.DaskBackend
+
+## I/O Functions
+
+::: colnade_dask.io.read_parquet
+
+::: colnade_dask.io.scan_parquet
+
+::: colnade_dask.io.read_csv
+
+::: colnade_dask.io.scan_csv
+
+::: colnade_dask.io.write_parquet
+
+::: colnade_dask.io.write_csv

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -15,3 +15,4 @@
 |--------|-------------|
 | [`colnade_polars`](polars.md) | Polars backend: PolarsBackend, I/O functions, dtype mapping |
 | [`colnade_pandas`](pandas.md) | Pandas backend: PandasBackend, I/O functions, dtype mapping |
+| [`colnade_dask`](dask.md) | Dask backend: DaskBackend, I/O functions, scan functions |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ plugins:
             - src
             - colnade-polars/src
             - colnade-pandas/src
+            - colnade-dask/src
           options:
             show_source: false
             show_root_heading: true
@@ -100,4 +101,5 @@ nav:
       - colnade.dtypes: api/types.md
       - colnade_polars: api/polars.md
       - colnade_pandas: api/pandas.md
+      - colnade_dask: api/dask.md
   - Comparison: comparison.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev-dependencies = [
     "ty>=0.0.1",
     "colnade-polars",
     "colnade-pandas",
+    "colnade-dask",
     # Documentation
     "mkdocs>=1.5",
     "mkdocs-material>=9.5",
@@ -52,12 +53,13 @@ dev-dependencies = [
 ]
 
 [tool.uv.workspace]
-members = ["colnade-polars", "colnade-pandas"]
+members = ["colnade-polars", "colnade-pandas", "colnade-dask"]
 
 [tool.uv.sources]
 colnade = { workspace = true }
 colnade-polars = { workspace = true }
 colnade-pandas = { workspace = true }
+colnade-dask = { workspace = true }
 
 [tool.ruff]
 target-version = "py310"
@@ -67,7 +69,7 @@ line-length = 100
 select = ["E", "F", "W", "I", "UP", "B", "SIM"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["colnade", "colnade_polars", "colnade_pandas"]
+known-first-party = ["colnade", "colnade_polars", "colnade_pandas", "colnade_dask"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/check_api_docs.py
+++ b/scripts/check_api_docs.py
@@ -20,6 +20,7 @@ PACKAGES: dict[str, str] = {
     "colnade": "src/colnade/__init__.py",
     "colnade_polars": "colnade-polars/src/colnade_polars/__init__.py",
     "colnade_pandas": "colnade-pandas/src/colnade_pandas/__init__.py",
+    "colnade_dask": "colnade-dask/src/colnade_dask/__init__.py",
 }
 
 
@@ -47,6 +48,7 @@ def main() -> int:
     sys.path.insert(0, str(root / "src"))
     sys.path.insert(0, str(root / "colnade-polars" / "src"))
     sys.path.insert(0, str(root / "colnade-pandas" / "src"))
+    sys.path.insert(0, str(root / "colnade-dask" / "src"))
 
     missing: list[tuple[str, str]] = []
 

--- a/tests/integration/test_dask_execution.py
+++ b/tests/integration/test_dask_execution.py
@@ -1,0 +1,433 @@
+"""Integration tests for Dask execution via the DataFrame layer."""
+
+from __future__ import annotations
+
+import dask.dataframe as dd
+import pandas as pd
+import pytest
+
+from colnade import Column, DataFrame, LazyFrame, Schema, SchemaError, UInt64, Utf8, mapped_from
+from colnade_dask.adapter import DaskBackend
+
+# ---------------------------------------------------------------------------
+# Test schemas
+# ---------------------------------------------------------------------------
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+    age: Column[UInt64]
+
+
+class Orders(Schema):
+    order_id: Column[UInt64]
+    user_id: Column[UInt64]
+    amount: Column[UInt64]
+
+
+class UserSummary(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+
+
+class RenamedUsers(Schema):
+    user_id: Column[UInt64] = mapped_from(Users.id)
+    user_name: Column[Utf8] = mapped_from(Users.name)
+
+
+class AgeStats(Schema):
+    name: Column[Utf8]
+    total_age: Column[UInt64]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _users_ddf() -> DataFrame[Users]:
+    data = pd.DataFrame(
+        {
+            "id": pd.array([1, 2, 3, 4, 5], dtype=pd.UInt64Dtype()),
+            "name": pd.array(["Alice", "Bob", "Charlie", "Diana", "Eve"], dtype=pd.StringDtype()),
+            "age": pd.array([30, 25, 35, 28, 40], dtype=pd.UInt64Dtype()),
+        }
+    )
+    ddf = dd.from_pandas(data, npartitions=2)
+    return DataFrame(_data=ddf, _schema=Users, _backend=DaskBackend())
+
+
+def _orders_ddf() -> DataFrame[Orders]:
+    data = pd.DataFrame(
+        {
+            "order_id": pd.array([101, 102, 103], dtype=pd.UInt64Dtype()),
+            "user_id": pd.array([1, 2, 1], dtype=pd.UInt64Dtype()),
+            "amount": pd.array([100, 200, 150], dtype=pd.UInt64Dtype()),
+        }
+    )
+    ddf = dd.from_pandas(data, npartitions=2)
+    return DataFrame(_data=ddf, _schema=Orders, _backend=DaskBackend())
+
+
+# ---------------------------------------------------------------------------
+# filter
+# ---------------------------------------------------------------------------
+
+
+class TestFilter:
+    def test_filter_by_comparison(self) -> None:
+        df = _users_ddf()
+        result = df.filter(Users.age > 30)
+        assert isinstance(result, DataFrame)
+        computed = result._data.compute()
+        assert computed.shape == (2, 3)
+        assert set(computed["name"].tolist()) == {"Charlie", "Eve"}
+
+    def test_filter_chained(self) -> None:
+        df = _users_ddf()
+        result = df.filter((Users.age >= 25) & (Users.age <= 35))
+        assert result._data.compute().shape == (4, 3)
+
+
+# ---------------------------------------------------------------------------
+# sort
+# ---------------------------------------------------------------------------
+
+
+class TestSort:
+    def test_sort_by_column(self) -> None:
+        df = _users_ddf()
+        result = df.sort(Users.age)
+        names = result._data.compute()["name"].tolist()
+        assert names == ["Bob", "Diana", "Alice", "Charlie", "Eve"]
+
+    def test_sort_descending(self) -> None:
+        df = _users_ddf()
+        result = df.sort(Users.age, descending=True)
+        names = result._data.compute()["name"].tolist()
+        assert names == ["Eve", "Charlie", "Alice", "Diana", "Bob"]
+
+    def test_sort_by_sort_expr(self) -> None:
+        df = _users_ddf()
+        result = df.sort(Users.age.desc())
+        names = result._data.compute()["name"].tolist()
+        assert names == ["Eve", "Charlie", "Alice", "Diana", "Bob"]
+
+
+# ---------------------------------------------------------------------------
+# limit / head / tail / sample
+# ---------------------------------------------------------------------------
+
+
+class TestSlicing:
+    def test_limit(self) -> None:
+        df = _users_ddf()
+        result = df.limit(2)
+        assert result._data.compute().shape[0] == 2
+
+    def test_head(self) -> None:
+        df = _users_ddf()
+        result = df.head(3)
+        assert result._data.compute().shape[0] == 3
+
+    def test_tail(self) -> None:
+        df = _users_ddf()
+        result = df.tail(2)
+        assert result._data.compute().shape[0] == 2
+
+    def test_sample(self) -> None:
+        df = _users_ddf()
+        result = df.sample(3)
+        assert result._data.compute().shape[0] == 3
+
+
+# ---------------------------------------------------------------------------
+# unique / drop_nulls
+# ---------------------------------------------------------------------------
+
+
+class TestUniqueDropNulls:
+    def test_unique(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1, 1, 2], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice", "Alice", "Bob"], dtype=pd.StringDtype()),
+                "age": pd.array([30, 30, 25], dtype=pd.UInt64Dtype()),
+            }
+        )
+        ddf = dd.from_pandas(data, npartitions=2)
+        df = DataFrame(_data=ddf, _schema=Users, _backend=DaskBackend())
+        result = df.unique(Users.name)
+        assert result._data.compute().shape[0] == 2
+
+    def test_drop_nulls(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1, 2, 3], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice", pd.NA, "Charlie"], dtype=pd.StringDtype()),
+                "age": pd.array([30, 25, 35], dtype=pd.UInt64Dtype()),
+            }
+        )
+        ddf = dd.from_pandas(data, npartitions=2)
+        df = DataFrame(_data=ddf, _schema=Users, _backend=DaskBackend())
+        result = df.drop_nulls(Users.name)
+        assert result._data.compute().shape[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# with_columns
+# ---------------------------------------------------------------------------
+
+
+class TestWithColumns:
+    def test_with_columns_computed(self) -> None:
+        df = _users_ddf()
+        result = df.with_columns((Users.age * 2).alias(Users.age))
+        ages = result._data.compute()["age"].tolist()
+        assert ages == [60, 50, 70, 56, 80]
+
+
+# ---------------------------------------------------------------------------
+# select
+# ---------------------------------------------------------------------------
+
+
+class TestSelect:
+    def test_select_subset(self) -> None:
+        df = _users_ddf()
+        result = df.select(Users.id, Users.name)
+        computed = result._data.compute()
+        assert list(computed.columns) == ["id", "name"]
+        assert computed.shape == (5, 2)
+
+
+# ---------------------------------------------------------------------------
+# group_by + agg
+# ---------------------------------------------------------------------------
+
+
+class TestGroupByAgg:
+    def test_group_by_sum(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1, 2, 3, 4], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice", "Alice", "Bob", "Bob"], dtype=pd.StringDtype()),
+                "age": pd.array([10, 20, 30, 40], dtype=pd.UInt64Dtype()),
+            }
+        )
+        ddf = dd.from_pandas(data, npartitions=2)
+        df = DataFrame(_data=ddf, _schema=Users, _backend=DaskBackend())
+        result = df.group_by(Users.name).agg(Users.age.sum().alias(Users.age))
+        result_data = result._data.compute().sort_values("name").reset_index(drop=True)
+        assert result_data["name"].tolist() == ["Alice", "Bob"]
+        assert result_data["age"].tolist() == [30, 70]
+
+
+# ---------------------------------------------------------------------------
+# join
+# ---------------------------------------------------------------------------
+
+
+class TestJoin:
+    def test_inner_join(self) -> None:
+        users = _users_ddf()
+        orders = _orders_ddf()
+        joined = users.join(orders, on=Users.id == Orders.user_id)
+        # Users 1 (Alice) has 2 orders, User 2 (Bob) has 1 order
+        assert joined._data.compute().shape[0] == 3
+
+
+# ---------------------------------------------------------------------------
+# cast_schema
+# ---------------------------------------------------------------------------
+
+
+class TestCastSchema:
+    def test_cast_schema_name_match(self) -> None:
+        df = _users_ddf()
+        result = df.cast_schema(UserSummary)
+        assert isinstance(result, DataFrame)
+        computed = result._data.compute()
+        assert list(computed.columns) == ["id", "name"]
+        assert computed.shape == (5, 2)
+
+    def test_cast_schema_mapped_from(self) -> None:
+        df = _users_ddf()
+        result = df.cast_schema(RenamedUsers)
+        assert isinstance(result, DataFrame)
+        computed = result._data.compute()
+        assert list(computed.columns) == ["user_id", "user_name"]
+        assert computed["user_id"].tolist() == [1, 2, 3, 4, 5]
+
+    def test_cast_schema_missing_raises(self) -> None:
+        class Bad(Schema):
+            id: Column[UInt64]
+            email: Column[Utf8]
+
+        df = _users_ddf()
+        with pytest.raises(SchemaError) as exc_info:
+            df.cast_schema(Bad)
+        assert "email" in exc_info.value.missing_columns
+
+
+# ---------------------------------------------------------------------------
+# lazy → collect roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestLazyCollect:
+    def test_lazy_filter_collect(self) -> None:
+        df = _users_ddf()
+        lf = df.lazy()
+        assert isinstance(lf, LazyFrame)
+        result = lf.filter(Users.age > 30).collect()
+        assert isinstance(result, DataFrame)
+        assert result._data.compute().shape == (2, 3)
+
+    def test_lazy_select_collect(self) -> None:
+        df = _users_ddf()
+        lf = df.lazy()
+        result = lf.select(Users.id, Users.name).collect()
+        assert list(result._data.compute().columns) == ["id", "name"]
+
+    def test_collect_materializes(self) -> None:
+        """Verify that collect() actually triggers computation."""
+        df = _users_ddf()
+        lf = df.lazy().filter(Users.age > 30)
+        result = lf.collect()
+        # After collect, the data should be a single-partition Dask DF
+        assert result._data.npartitions == 1
+        assert result._data.compute().shape == (2, 3)
+
+
+# ---------------------------------------------------------------------------
+# validate
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def test_validate_passes(self) -> None:
+        df = _users_ddf()
+        result = df.validate()
+        assert result is df
+
+    def test_validate_fails_missing_column(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice"], dtype=pd.StringDtype()),
+                # missing "age"
+            }
+        )
+        ddf = dd.from_pandas(data, npartitions=1)
+        df = DataFrame(_data=ddf, _schema=Users, _backend=DaskBackend())
+        with pytest.raises(SchemaError) as exc_info:
+            df.validate()
+        assert "age" in exc_info.value.missing_columns
+
+    def test_validate_fails_type_mismatch(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": [1, 2],  # int64, not UInt64
+                "name": ["Alice", "Bob"],  # object, not StringDtype
+                "age": [30, 25],  # int64, not UInt64
+            }
+        )
+        ddf = dd.from_pandas(data, npartitions=1)
+        df = DataFrame(_data=ddf, _schema=Users, _backend=DaskBackend())
+        with pytest.raises(SchemaError) as exc_info:
+            df.validate()
+        assert len(exc_info.value.type_mismatches) > 0
+
+
+# ---------------------------------------------------------------------------
+# Introspection properties
+# ---------------------------------------------------------------------------
+
+
+class TestIntrospection:
+    def test_height(self) -> None:
+        df = _users_ddf()
+        assert df.height == 5
+
+    def test_len(self) -> None:
+        df = _users_ddf()
+        assert len(df) == 5
+
+    def test_width(self) -> None:
+        df = _users_ddf()
+        assert df.width == 3
+
+    def test_shape(self) -> None:
+        df = _users_ddf()
+        assert df.shape == (5, 3)
+
+    def test_is_empty_false(self) -> None:
+        df = _users_ddf()
+        assert df.is_empty() is False
+
+    def test_is_empty_true(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([], dtype=pd.UInt64Dtype()),
+                "name": pd.array([], dtype=pd.StringDtype()),
+                "age": pd.array([], dtype=pd.UInt64Dtype()),
+            }
+        )
+        ddf = dd.from_pandas(data, npartitions=1)
+        df = DataFrame(_data=ddf, _schema=Users, _backend=DaskBackend())
+        assert df.is_empty() is True
+
+    def test_height_after_filter(self) -> None:
+        df = _users_ddf().filter(Users.age > 30)
+        assert df.height == 2
+
+    def test_lazyframe_width(self) -> None:
+        lf = _users_ddf().lazy()
+        assert lf.width == 3
+
+
+# ---------------------------------------------------------------------------
+# iter_rows_as
+# ---------------------------------------------------------------------------
+
+
+class TestIterRowsAs:
+    def test_iter_rows_as_dict(self) -> None:
+        df = _users_ddf()
+        rows = list(df.iter_rows_as(dict))
+        assert len(rows) == 5
+        assert rows[0] == {"id": 1, "name": "Alice", "age": 30}
+
+    def test_iter_rows_as_schema_row(self) -> None:
+        df = _users_ddf()
+        rows = list(df.iter_rows_as(Users.Row))
+        assert len(rows) == 5
+        assert rows[0].id == 1
+        assert rows[0].name == "Alice"
+        assert rows[0].age == 30
+
+    def test_iter_rows_as_schema_row_type(self) -> None:
+        df = _users_ddf()
+        rows = list(df.iter_rows_as(Users.Row))
+        assert type(rows[0]).__name__ == "UsersRow"
+
+    def test_iter_rows_as_empty(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([], dtype=pd.UInt64Dtype()),
+                "name": pd.array([], dtype=pd.StringDtype()),
+                "age": pd.array([], dtype=pd.UInt64Dtype()),
+            }
+        )
+        ddf = dd.from_pandas(data, npartitions=1)
+        df = DataFrame(_data=ddf, _schema=Users, _backend=DaskBackend())
+        rows = list(df.iter_rows_as(Users.Row))
+        assert rows == []
+
+    def test_iter_rows_as_after_filter(self) -> None:
+        df = _users_ddf().filter(Users.age > 35)
+        rows = list(df.iter_rows_as(Users.Row))
+        assert len(rows) == 1
+        assert rows[0].name == "Eve"

--- a/tests/integration/test_dask_io.py
+++ b/tests/integration/test_dask_io.py
@@ -1,0 +1,139 @@
+"""Integration tests for Dask I/O functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import dask.dataframe as dd
+import pandas as pd
+import pytest
+
+import colnade.validation
+from colnade import Column, DataFrame, LazyFrame, Schema, SchemaError, UInt64, Utf8
+from colnade_dask.adapter import DaskBackend
+from colnade_dask.io import (
+    read_csv,
+    read_parquet,
+    scan_csv,
+    scan_parquet,
+    write_csv,
+    write_parquet,
+)
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+    age: Column[UInt64]
+
+
+class WrongSchema(Schema):
+    id: Column[UInt64]
+    email: Column[Utf8]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sample_ddf() -> dd.DataFrame:
+    pdf = pd.DataFrame(
+        {
+            "id": pd.array([1, 2, 3], dtype=pd.UInt64Dtype()),
+            "name": pd.array(["Alice", "Bob", "Charlie"], dtype=pd.StringDtype()),
+            "age": pd.array([30, 25, 35], dtype=pd.UInt64Dtype()),
+        }
+    )
+    return dd.from_pandas(pdf, npartitions=2)
+
+
+# ---------------------------------------------------------------------------
+# Parquet roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestParquetRoundtrip:
+    def test_write_read_parquet(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "users.parquet")
+        data = _sample_ddf()
+        df = DataFrame(_data=data, _schema=Users, _backend=DaskBackend())
+        write_parquet(df, path)
+
+        result = read_parquet(path, Users)
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+        computed = result._data.compute()
+        assert computed.shape == (3, 3)
+        assert computed["name"].tolist() == ["Alice", "Bob", "Charlie"]
+
+    def test_scan_parquet(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "users.parquet")
+        _sample_ddf().to_parquet(path)
+
+        result = scan_parquet(path, Users)
+        assert isinstance(result, LazyFrame)
+        assert result._schema is Users
+        collected = result.collect()
+        assert collected._data.compute().shape == (3, 3)
+
+    def test_scan_parquet_filter_collect(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "users.parquet")
+        _sample_ddf().to_parquet(path)
+
+        result = scan_parquet(path, Users).filter(Users.age > 28).collect()
+        assert result._data.compute().shape[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# CSV roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestCsvRoundtrip:
+    def test_write_read_csv(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "users.csv")
+        data = _sample_ddf()
+        df = DataFrame(_data=data, _schema=Users, _backend=DaskBackend())
+        write_csv(df, path)
+
+        result = read_csv(path, Users)
+        assert isinstance(result, DataFrame)
+        assert result._schema is Users
+        computed = result._data.compute()
+        assert computed.shape == (3, 3)
+        assert computed["name"].tolist() == ["Alice", "Bob", "Charlie"]
+
+    def test_scan_csv(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "users.csv")
+        _sample_ddf().compute().to_csv(path, index=False)
+
+        result = scan_csv(path, Users)
+        assert isinstance(result, LazyFrame)
+        collected = result.collect()
+        assert collected._data.compute().shape == (3, 3)
+
+
+# ---------------------------------------------------------------------------
+# Schema mismatch
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaMismatch:
+    def setup_method(self) -> None:
+        colnade.validation.set_validation(True)
+
+    def teardown_method(self) -> None:
+        colnade.validation._validation_enabled = None
+
+    def test_read_parquet_wrong_schema(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "users.parquet")
+        _sample_ddf().to_parquet(path)
+
+        with pytest.raises(SchemaError) as exc_info:
+            read_parquet(path, WrongSchema)
+        assert "email" in exc_info.value.missing_columns

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ resolution-markers = [
 [manifest]
 members = [
     "colnade",
+    "colnade-dask",
     "colnade-pandas",
     "colnade-polars",
 ]
@@ -152,6 +153,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228 },
+]
+
+[[package]]
 name = "colnade"
 version = "0.2.0"
 source = { editable = "." }
@@ -161,6 +171,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "colnade-dask" },
     { name = "colnade-pandas" },
     { name = "colnade-polars" },
     { name = "mkdocs" },
@@ -177,6 +188,7 @@ requires-dist = [{ name = "typing-extensions", specifier = ">=4.0" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "colnade-dask", editable = "colnade-dask" },
     { name = "colnade-pandas", editable = "colnade-pandas" },
     { name = "colnade-polars", editable = "colnade-polars" },
     { name = "mkdocs", specifier = ">=1.5" },
@@ -186,6 +198,25 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.0" },
     { name = "ruff", specifier = ">=0.4" },
     { name = "ty", specifier = ">=0.0.1" },
+]
+
+[[package]]
+name = "colnade-dask"
+version = "0.1.0"
+source = { editable = "colnade-dask" }
+dependencies = [
+    { name = "colnade" },
+    { name = "colnade-pandas" },
+    { name = "dask", extra = ["dataframe"] },
+    { name = "pyarrow" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "colnade", editable = "." },
+    { name = "colnade-pandas", editable = "colnade-pandas" },
+    { name = "dask", extras = ["dataframe"], specifier = ">=2024.1" },
+    { name = "pyarrow", specifier = ">=12.0" },
 ]
 
 [[package]]
@@ -351,15 +382,52 @@ toml = [
 ]
 
 [[package]]
+name = "dask"
+version = "2026.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "cloudpickle" },
+    { name = "fsspec" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "packaging" },
+    { name = "partd" },
+    { name = "pyyaml" },
+    { name = "toolz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/52/b0f9172b22778def907db1ff173249e4eb41f054b46a9c83b1528aaf811f/dask-2026.1.2.tar.gz", hash = "sha256:1136683de2750d98ea792670f7434e6c1cfce90cab2cc2f2495a9e60fd25a4fc", size = 10997838 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/23/d39ccc4ed76222db31530b0a7d38876fdb7673e23f838e8d8f0ed4651a4f/dask-2026.1.2-py3-none-any.whl", hash = "sha256:46a0cf3b8d87f78a3d2e6b145aea4418a6d6d606fe6a16c79bd8ca2bb862bc91", size = 1482084 },
+]
+
+[package.optional-dependencies]
+dataframe = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyarrow" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740 },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505 },
 ]
 
 [[package]]
@@ -416,6 +484,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp", marker = "python_full_version < '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865 },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -434,6 +514,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
+]
+
+[[package]]
+name = "locket"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/83/97b29fe05cb6ae28d2dbd30b81e2e402a3eed5f460c26e9eaa5895ceacf5/locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632", size = 4350 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3", size = 4398 },
 ]
 
 [[package]]
@@ -962,6 +1051,19 @@ wheels = [
 ]
 
 [[package]]
+name = "partd"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "locket" },
+    { name = "toolz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/3a/3f06f34820a31257ddcabdfafc2672c5816be79c7e353b02c1f318daa7d4/partd-1.4.2.tar.gz", hash = "sha256:d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c", size = 21029 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl", hash = "sha256:978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f", size = 18905 },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1328,6 +1430,15 @@ wheels = [
 ]
 
 [[package]]
+name = "toolz"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093 },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.16"
 source = { registry = "https://pypi.org/simple" }
@@ -1408,4 +1519,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276 },
 ]


### PR DESCRIPTION
## Summary

- Implements full `BackendProtocol` for Dask as a new workspace package `colnade-dask`
- Reuses `colnade-pandas` dtype mapping (Dask uses Pandas dtypes internally)
- Same callable-based expression translation as PandasBackend — callables build lazy Dask task graphs instead of executing immediately
- Key differences from Pandas adapter:
  - `collect()` calls `.compute()` and re-wraps in Dask DF so DaskBackend continues working
  - `head()`/`limit()` use Dask's lazy `compute=False` variant
  - `tail()`/`sample()` compute and re-wrap (no lazy Dask equivalent)
  - `validate_schema()` handles `StringDtype` storage backend variation (python vs pyarrow)
  - Null checks in validation use `.compute()` since Dask is lazy
- Includes `scan_csv`/`scan_parquet` returning `LazyFrame` (Dask reads are naturally lazy)
- 43 integration tests (37 execution + 6 I/O) with `npartitions=2` to exercise partition handling
- Updates docs (API reference, mkdocs nav, index page) and `check_api_docs.py`

Closes #38

## Test plan

- [x] All 838 tests pass (`uv run pytest tests/ -v`)
- [x] Ruff lint and format clean
- [x] ty type checker passes
- [x] API docs coverage check passes
- [x] `mkdocs build --strict` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)