### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Build colnade-polars
         run: uv build --package colnade-polars --out-dir dist-colnade-polars/
 
+      - name: Build colnade-pandas
+        run: uv build --package colnade-pandas --out-dir dist-colnade-pandas/
+
+      - name: Build colnade-dask
+        run: uv build --package colnade-dask --out-dir dist-colnade-dask/
+
       - uses: actions/upload-artifact@v4
         with:
           name: dist-colnade
@@ -29,6 +35,16 @@ jobs:
         with:
           name: dist-colnade-polars
           path: dist-colnade-polars/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-colnade-pandas
+          path: dist-colnade-pandas/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-colnade-dask
+          path: dist-colnade-dask/
 
   publish-colnade:
     needs: build
@@ -61,6 +77,42 @@ jobs:
           path: dist/
 
       - name: Publish colnade-polars to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+
+  publish-colnade-pandas:
+    needs: publish-colnade
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-colnade-pandas
+          path: dist/
+
+      - name: Publish colnade-pandas to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+
+  publish-colnade-dask:
+    needs: publish-colnade-pandas
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-colnade-dask
+          path: dist/
+
+      - name: Publish colnade-dask to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/

--- a/colnade-dask/pyproject.toml
+++ b/colnade-dask/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "colnade>=0.2.0",
+    "colnade>=0.3.0",
     "colnade-pandas>=0.1.0",
     "dask[dataframe]>=2024.1",
     "pyarrow>=12.0",

--- a/colnade-pandas/pyproject.toml
+++ b/colnade-pandas/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "colnade>=0.2.0",
+    "colnade>=0.3.0",
     "pandas>=2.0",
     "pyarrow>=12.0",
 ]

--- a/colnade-polars/pyproject.toml
+++ b/colnade-polars/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "colnade-polars"
-version = "0.2.0"
+version = "0.3.0"
 description = "Polars backend adapter for Colnade"
 requires-python = ">=3.10"
 license = "MIT"
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "colnade>=0.2.0",
+    "colnade>=0.3.0",
     "polars>=0.20",
     "pyarrow>=12.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "colnade"
-version = "0.2.0"
+version = "0.3.0"
 description = "A statically type-safe DataFrame abstraction layer"
 requires-python = ">=3.10"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,7 @@ wheels = [
 
 [[package]]
 name = "colnade"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },
@@ -239,7 +239,7 @@ requires-dist = [
 
 [[package]]
 name = "colnade-polars"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "colnade-polars" }
 dependencies = [
     { name = "colnade" },


### PR DESCRIPTION
## Summary

- Bump `colnade` from 0.2.0 → 0.3.0
- Bump `colnade-polars` from 0.2.0 → 0.3.0
- Update dependency pins to `colnade>=0.3.0` in all backend adapters
- Add `colnade-pandas` and `colnade-dask` build/publish jobs to the PyPI publish workflow

## Changes since v0.2.0

- **PR #57**: Fix implementation gaps (joined frames, backend requirement, untyped delegation)
- **PR #59**: Schema.Row type, DataFrame introspection properties (height/width/shape/is_empty), iter_rows_as
- **PR #61**: CI check for API docs coverage
- **PR #62**: New Pandas backend adapter (`colnade-pandas` v0.1.0)
- **PR #63**: New Dask backend adapter (`colnade-dask` v0.1.0)

## Test plan

- [x] 838 tests pass
- [x] Ruff clean
- [ ] Merge, tag v0.3.0, create GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)