### PR TITLE
Update docs to reflect Pandas and Dask backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ Works with [ty](https://github.com/astral-sh/ty), mypy, and pyright. No plugins,
 pip install colnade colnade-polars
 ```
 
-Colnade requires Python 3.10+. The `colnade-polars` package provides the Polars backend adapter.
+Colnade requires Python 3.10+. Install the backend adapter for your engine:
+
+| Backend | Install |
+|---------|---------|
+| Polars | `pip install colnade-polars` |
+| Pandas | `pip install colnade-pandas` |
+| Dask | `pip install colnade-dask` |
 
 ## Quick Start
 
@@ -210,14 +216,15 @@ assignable to `Column[UInt8]`
 
 ## Comparison with Existing Solutions
 
-| Feature | Colnade | Pandera | StaticFrame | Patito |
-|---------|---------|---------|-------------|--------|
-| Column refs checked statically | Yes | No | No | No |
-| Schema preserved through ops | Yes | Nominal only | No | No |
-| Works with existing engines | Yes | Yes | No | Polars only |
-| No plugins or code gen | Yes | No (mypy plugin) | Yes | Yes |
-| Generic utility functions | Yes | No | No | No |
-| Struct/List typed access | Yes | No | No | No |
+| Feature | Colnade | Pandera | StaticFrame | Patito | Narwhals |
+|---------|---------|---------|-------------|--------|----------|
+| Column refs checked statically | Yes | No | No | No | No |
+| Schema preserved through ops | Yes | Nominal only | No | No | No |
+| Works with existing engines | Yes | Yes | No | Polars only | Yes |
+| No plugins or code gen | Yes | No (mypy plugin) | Yes | Yes | Yes |
+| Generic utility functions | Yes | No | No | No | No |
+| Struct/List typed access | Yes | No | No | No | No |
+| Lazy execution support | Yes | No | No | No | Yes |
 
 ## Documentation
 

--- a/colnade-dask/README.md
+++ b/colnade-dask/README.md
@@ -1,3 +1,35 @@
 # colnade-dask
 
-Dask backend adapter for [Colnade](https://github.com/jwde/colnade).
+Dask backend adapter for [Colnade](https://github.com/jwde/colnade). Supports lazy evaluation and distributed computation.
+
+## Installation
+
+```bash
+pip install colnade-dask
+```
+
+## Usage
+
+```python
+from colnade import Column, Schema, UInt64, Float64, Utf8
+from colnade_dask import scan_parquet
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+    age: Column[UInt64]
+    score: Column[Float64]
+
+lf = scan_parquet("users.parquet", Users)
+result = lf.filter(Users.age > 25).sort(Users.score.desc()).collect()
+```
+
+## I/O Functions
+
+- `read_parquet` / `write_parquet` (eager)
+- `scan_parquet` / `scan_csv` (lazy)
+- `read_csv` / `write_csv`
+
+## Documentation
+
+Full documentation at [colnade.com](https://colnade.com/).

--- a/colnade-pandas/README.md
+++ b/colnade-pandas/README.md
@@ -1,3 +1,34 @@
 # colnade-pandas
 
 Pandas backend adapter for [Colnade](https://github.com/jwde/colnade).
+
+## Installation
+
+```bash
+pip install colnade-pandas
+```
+
+## Usage
+
+```python
+from colnade import Column, Schema, UInt64, Float64, Utf8
+from colnade_pandas import read_parquet
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+    age: Column[UInt64]
+    score: Column[Float64]
+
+df = read_parquet("users.parquet", Users)
+result = df.filter(Users.age > 25).sort(Users.score.desc())
+```
+
+## I/O Functions
+
+- `read_parquet` / `write_parquet`
+- `read_csv` / `write_csv`
+
+## Documentation
+
+Full documentation at [colnade.com](https://colnade.com/).

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,13 +11,21 @@
 pip install colnade colnade-polars
 ```
 
-`colnade` provides the core abstraction layer. `colnade-polars` provides the Polars backend adapter.
+`colnade` provides the core abstraction layer. Install the backend adapter for your engine:
+
+| Backend | Install |
+|---------|---------|
+| Polars | `pip install colnade-polars` |
+| Pandas | `pip install colnade-pandas` |
+| Dask | `pip install colnade-dask` |
 
 ## Install with uv
 
 ```bash
 uv add colnade colnade-polars
 ```
+
+Or substitute `colnade-pandas` / `colnade-dask` for your preferred backend.
 
 ## Install from source
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ Works with [ty](https://github.com/astral-sh/ty), mypy, and pyright. No plugins,
 - **Type-safe column references** — `Users.naem` is a type error, not a runtime crash
 - **Schema-preserving operations** — `filter`, `sort`, `with_columns` preserve `DataFrame[S]`
 - **Typed expressions** — `Users.age > 18` produces `Expr[Bool]`, `Users.score * 2` produces `Expr[Float64]`
-- **Backend agnostic** — works with Polars today, with adapters for other engines
+- **Backend agnostic** — works with Polars, Pandas, and Dask
 - **Generic utility functions** — write `def f(df: DataFrame[S]) -> DataFrame[S]` that works with any schema
 - **Struct and List support** — typed access to nested data structures
 - **No plugins or codegen** — works with standard type checkers out of the box

--- a/docs/tutorials/full-pipeline.md
+++ b/docs/tutorials/full-pipeline.md
@@ -30,7 +30,7 @@ class UserRevenue(Schema):
 ## Step 1: Read typed data
 
 ```python
-from colnade_polars.io import read_parquet
+from colnade_polars import read_parquet
 
 users = read_parquet("users.parquet", Users)
 orders = read_parquet("orders.parquet", Orders)

--- a/docs/user-guide/core-concepts.md
+++ b/docs/user-guide/core-concepts.md
@@ -14,8 +14,7 @@ graph TD
   D --> E
   E --> F["Polars"]
   E --> G["Pandas"]
-  E --> H["DuckDB"]
-  E --> I["Spark"]
+  E --> H["Dask"]
 ```
 
 ## Schema Layer
@@ -63,9 +62,13 @@ After a schema-transforming operation, use `cast_schema()` to bind to a new name
 
 Backends translate expression trees and execute operations. The core library defines a `BackendProtocol`; each adapter implements it for a specific engine.
 
-Currently available: **`colnade-polars`** (Polars backend)
+Available adapters:
 
-When you call `read_parquet("data.parquet", Users)`, the Polars backend is automatically attached. All subsequent operations on the DataFrame delegate to Polars under the hood.
+- **`colnade-polars`** — Polars backend (eager + lazy)
+- **`colnade-pandas`** — Pandas backend (eager)
+- **`colnade-dask`** — Dask backend (lazy, distributed)
+
+When you call `read_parquet("data.parquet", Users)`, the backend is automatically attached. All subsequent operations on the DataFrame delegate to the underlying engine.
 
 ## The Type Safety Model
 


### PR DESCRIPTION
## Summary

- Update architecture diagram: replace DuckDB/Spark with Pandas/Dask
- Core concepts: list all three available backend adapters (was "only colnade-polars")
- Installation page: add backend selection table with Polars/Pandas/Dask
- Homepage + README: update "backend agnostic" to name all three backends
- README comparison table: add Narwhals column (matches docs/comparison.md)
- Expand colnade-pandas and colnade-dask READMEs from stubs to include install/usage/docs links
- Fix inconsistent import in full-pipeline tutorial

Closes #65

## Test plan

- [x] `mkdocs build --strict` passes
- [ ] Visual review of rendered docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)