### PR TITLE
Add validation levels: off / structural / full

### DIFF
--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -45,3 +45,7 @@ Schema base class, Column descriptors, backend protocol, and supporting utilitie
 ## is_validation_enabled
 
 ::: colnade.validation.is_validation_enabled
+
+## get_validation_level
+
+::: colnade.validation.get_validation_level

--- a/docs/user-guide/dataframes.md
+++ b/docs/user-guide/dataframes.md
@@ -144,7 +144,34 @@ Validate that data conforms to the schema:
 df.validate()  # raises SchemaError on mismatch
 ```
 
-Checks column existence and data types. Enable auto-validation at data boundaries with `COLNADE_VALIDATE=1` or `colnade.set_validation(True)`.
+Checks column existence, data types, and nullability constraints.
+
+### Validation levels
+
+| Level | Behavior |
+|-------|----------|
+| `"off"` | No runtime checks. Trust the type checker. Zero overhead. (default) |
+| `"structural"` | Check columns exist, dtypes match, nullability. Also checks literal type compatibility in expressions. |
+| `"full"` | Structural checks plus value-level constraints from `Field()` metadata. |
+
+Enable auto-validation at data boundaries:
+
+```python
+import colnade
+
+colnade.set_validation("structural")  # or "full"
+# Boolean still works: set_validation(True) → "structural"
+```
+
+Or via environment variable:
+
+```bash
+COLNADE_VALIDATE=structural pytest tests/
+COLNADE_VALIDATE=full pytest tests/
+# Legacy: COLNADE_VALIDATE=1 → "structural"
+```
+
+`df.validate()` always runs the full level of checks regardless of the toggle — calling it explicitly signals intent.
 
 ## What Colnade validates
 

--- a/src/colnade/__init__.py
+++ b/src/colnade/__init__.py
@@ -53,7 +53,7 @@ from colnade.expr import (
     lit,
 )
 from colnade.schema import Column, ListAccessor, Schema, SchemaError, mapped_from
-from colnade.validation import is_validation_enabled, set_validation
+from colnade.validation import get_validation_level, is_validation_enabled, set_validation
 
 __all__ = [
     # Backend
@@ -123,4 +123,5 @@ __all__ = [
     # Validation
     "set_validation",
     "is_validation_enabled",
+    "get_validation_level",
 ]

--- a/tests/integration/test_dask_io.py
+++ b/tests/integration/test_dask_io.py
@@ -128,7 +128,7 @@ class TestSchemaMismatch:
         colnade.validation.set_validation(True)
 
     def teardown_method(self) -> None:
-        colnade.validation._validation_enabled = None
+        colnade.validation._validation_level = None
 
     def test_read_parquet_wrong_schema(self, tmp_path: Path) -> None:
         path = str(tmp_path / "users.parquet")

--- a/tests/integration/test_pandas_io.py
+++ b/tests/integration/test_pandas_io.py
@@ -103,7 +103,7 @@ class TestSchemaMismatch:
         colnade.validation.set_validation(True)
 
     def teardown_method(self) -> None:
-        colnade.validation._validation_enabled = None
+        colnade.validation._validation_level = None
 
     def test_read_parquet_wrong_schema(self, tmp_path: Path) -> None:
         path = str(tmp_path / "users.parquet")

--- a/tests/integration/test_polars_io.py
+++ b/tests/integration/test_polars_io.py
@@ -127,7 +127,7 @@ class TestSchemaMismatch:
         colnade.validation.set_validation(True)
 
     def teardown_method(self) -> None:
-        colnade.validation._validation_enabled = None
+        colnade.validation._validation_level = None
 
     def test_read_parquet_wrong_schema(self, tmp_path: Path) -> None:
         path = str(tmp_path / "users.parquet")

--- a/tests/integration/test_validation_polars.py
+++ b/tests/integration/test_validation_polars.py
@@ -135,10 +135,10 @@ class TestLazyFrameValidate:
 
 class TestValidationToggle:
     def setup_method(self) -> None:
-        colnade.validation._validation_enabled = None
+        colnade.validation._validation_level = None
 
     def teardown_method(self) -> None:
-        colnade.validation._validation_enabled = None
+        colnade.validation._validation_level = None
 
     def test_read_parquet_no_validation_by_default(self, tmp_path) -> None:
         """With validation off, mismatched parquet loads without error."""


### PR DESCRIPTION
## Summary

- Replace binary validation toggle with three levels: `"off"`, `"structural"`, `"full"`
- `set_validation()` accepts both `bool` (backward compat) and `str`
- `COLNADE_VALIDATE` env var accepts `off|structural|full|0|1|true|yes`
- New `get_validation_level()` returns the current level as a string
- `is_validation_enabled()` unchanged — returns `True` for structural or full
- `"full"` is currently equivalent to `"structural"` until value constraints ship (#69)
- Updated docs with validation levels table

Closes #67

## Test plan

- [x] 851 tests pass (13 new level tests + all existing tests)
- [x] Backward compatibility: `set_validation(True/False)` and `COLNADE_VALIDATE=1` still work
- [x] Invalid level string raises `ValueError`
- [x] Ruff clean, mkdocs strict clean, API docs coverage clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)