### PR TITLE
Docs: lead with the complete three-level safety story

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ output = result.cast_schema(UserSummary)
 # output is DataFrame[UserSummary]
 ```
 
+## Safety Model
+
+Colnade catches errors at three levels:
+
+1. **In your editor** — misspelled columns, type mismatches, and schema violations are flagged by your type checker (`ty`, `pyright`, `mypy`) before code runs
+2. **At data boundaries** — runtime validation ensures files and external data match your schemas (columns, types, nullability)
+3. **On your data values** — field constraints validate domain invariants like ranges and patterns *(coming soon)*
+
 ## Key Features
 
 ### Type-safe column references

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,11 +52,18 @@ Works with [ty](https://github.com/astral-sh/ty), mypy, and pyright. No plugins,
 
 ---
 
+## Errors Caught at Three Levels
+
+1. **In your editor** — misspelled columns, type mismatches, and schema violations are flagged by your type checker before code runs
+2. **At data boundaries** — runtime validation ensures files and external data match your schemas (columns, types, nullability)
+3. **On your data values** — field constraints validate domain invariants like ranges and patterns *(coming soon)*
+
 ## Key Features
 
 - **Type-safe column references** — `Users.naem` is a type error, not a runtime crash
 - **Schema-preserving operations** — `filter`, `sort`, `with_columns` preserve `DataFrame[S]`
 - **Typed expressions** — `Users.age > 18` produces `Expr[Bool]`, `Users.score * 2` produces `Expr[Float64]`
+- **Runtime validation** — `df.validate()` checks columns, types, and nullability; auto-validate at data boundaries with a single toggle
 - **Backend agnostic** — works with Polars, Pandas, and Dask
 - **Generic utility functions** — write `def f(df: DataFrame[S]) -> DataFrame[S]` that works with any schema
 - **Struct and List support** — typed access to nested data structures

--- a/docs/user-guide/dataframes.md
+++ b/docs/user-guide/dataframes.md
@@ -148,21 +148,29 @@ Checks column existence and data types. Enable auto-validation at data boundarie
 
 ## What Colnade validates
 
-Colnade provides type safety at two levels:
+Colnade catches errors at three levels (see also [Core Concepts: Safety Model](core-concepts.md#the-safety-model)):
 
-### Static analysis (ty, pyright, mypy)
+### Level 1: In your editor (static analysis)
+
+Your type checker (`ty`, `pyright`, `mypy`) catches errors before code runs:
 
 - **Schema-aware return types** — `df.filter(...)` returns `DataFrame[Users]`, not just `DataFrame`
 - **Type boundary enforcement** — `JoinedDataFrame[S, S2]` is a distinct type from `DataFrame[S]`. You cannot pass a joined frame where a `DataFrame` is expected — you must `cast_schema()` first
 - **Schema-transforming operations** — `select()` and `group_by().agg()` return `DataFrame[Any]`, requiring `cast_schema()` to regain a named schema
 - **Join conditions** — cross-schema `==` returns `JoinCondition`, same-schema `==` returns `BinOp[Bool]`
 
-### Runtime validation (df.validate())
+### Level 2: At data boundaries (runtime structural validation)
+
+When validation is enabled, data boundaries and `df.validate()` check:
 
 - **Column existence** — missing columns raise `SchemaError`
 - **Data types** — type mismatches raise `SchemaError`
 - **Null violations** — non-nullable columns with null values raise `SchemaError`
 - **Extra columns** — optionally flagged via `extra="forbid"` on `cast_schema()`
+
+### Level 3: On your data values (coming soon)
+
+Value-level constraints will validate domain invariants — ranges, patterns, uniqueness — using field metadata.
 
 ### Current limitations
 


### PR DESCRIPTION
## Summary

- Add "Errors Caught at Three Levels" section to homepage and README
- Restructure core concepts "Type Safety Model" → "Safety Model" with three subsections
- Restructure dataframes "What Colnade validates" around the same three levels
- Add "Runtime validation" bullet to homepage Key Features list
- Level 3 ("data values") marked as "coming soon" pending #69

The runtime validation story was previously undersold — a reviewer might have concluded Colnade has no runtime story at all.

Closes #68

## Test plan

- [x] `mkdocs build --strict` passes
- [ ] Visual review of rendered pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)