### PR TITLE
Document cast_schema as a trust boundary

### DIFF
--- a/docs/user-guide/core-concepts.md
+++ b/docs/user-guide/core-concepts.md
@@ -84,6 +84,8 @@ Your type checker (`ty`, `pyright`, `mypy`) catches errors before code runs:
 
 Operations within function bodies (e.g., using `Orders.amount` on a `DataFrame[Users]`) produce correct expression types but cannot be statically checked for schema membership — this is a known limitation documented in [Type Checker Integration](type-checking.md).
 
+`cast_schema()` is the primary trust boundary: the type checker verifies input expressions, but the developer asserts the output conforms. Use `mapped_from` on output schema fields and `extra="forbid"` to narrow the gap. See [DataFrames: cast_schema](dataframes.md#cast_schema-is-a-trust-boundary) for details.
+
 ### 2. At data boundaries (runtime structural validation)
 
 When validation is enabled, data boundaries (`read_parquet`, `from_batches`, `cast_schema`) verify that actual data matches your schema:


### PR DESCRIPTION
## Summary

- Add "cast_schema is a trust boundary" subsection to the dataframes guide
- Frame it as analogous to a type cast — necessary but verify
- Recommend three mitigations: `mapped_from`, `extra="forbid"`, `.validate()`
- Cross-reference from the core concepts safety model section

Closes #71

## Test plan

- [x] `mkdocs build --strict` passes
- [x] `ruff format --check` passes
- [ ] Visual review of rendered docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)