### PR TITLE
Document Field() constraints across all docs

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,7 +4,7 @@
 
 | Module | Description |
 |--------|-------------|
-| [`colnade core`](schema.md) | Schema, Column, BackendProtocol, ArrowBatch, validation utilities |
+| [`colnade core`](schema.md) | Schema, Column, Field, FieldInfo, ValidationLevel, BackendProtocol, ArrowBatch |
 | [`colnade.dataframe`](dataframe.md) | DataFrame, LazyFrame, GroupBy, JoinedDataFrame, Untyped frames |
 | [`colnade.expr`](expressions.md) | Expression AST nodes (ColumnRef, BinOp, Agg, etc.) |
 | [`colnade.dtypes`](types.md) | Data type definitions (UInt64, Float64, Utf8, Struct, List, etc.) |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,6 +11,7 @@
 | Generic utility functions | :white_check_mark: | :x: | :x: | :x: | :x: |
 | Struct/List typed access | :white_check_mark: | :x: | :x: | :x: | :x: |
 | Lazy execution support | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: |
+| Value-level constraints | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :x: |
 
 ## Detailed Comparisons
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -27,7 +27,7 @@ df = read_parquet("users.parquet", Users)
 # df is DataFrame[Users] — the type checker knows the schema
 ```
 
-The `read_parquet` function validates the data against the schema and returns a `DataFrame[Users]` with the Polars backend attached.
+The `read_parquet` function returns a `DataFrame[Users]` with the Polars backend attached. When [validation is enabled](../user-guide/dataframes.md#validation), it also checks that the data matches the schema.
 
 ## 3. Transform with type safety
 

--- a/docs/tutorials/basic-usage.md
+++ b/docs/tutorials/basic-usage.md
@@ -30,7 +30,7 @@ df = read_parquet("users.parquet", Users)
 # df is DataFrame[Users] — the type checker knows the schema
 ```
 
-`read_parquet` validates the file's columns and types against the schema, then returns a `DataFrame[Users]` with the Polars backend attached.
+`read_parquet` returns a `DataFrame[Users]` with the Polars backend attached. When [validation is enabled](../user-guide/dataframes.md#validation), it also checks columns and types against the schema.
 
 ## Filter rows
 

--- a/docs/tutorials/full-pipeline.md
+++ b/docs/tutorials/full-pipeline.md
@@ -36,7 +36,7 @@ users = read_parquet("users.parquet", Users)
 orders = read_parquet("orders.parquet", Orders)
 ```
 
-Both `read_parquet` calls validate the data against their schema and attach the Polars backend.
+Both `read_parquet` calls return typed DataFrames with the Polars backend attached. When [validation is enabled](../user-guide/dataframes.md#validation), they also check the data against the schemas.
 
 ## Step 2: Clean nulls
 

--- a/docs/user-guide/type-checking.md
+++ b/docs/user-guide/type-checking.md
@@ -73,16 +73,21 @@ Users.name > 42           # NOT caught — int compared to string
 
 This is a fundamental limitation — Python lacks type-level functions to map `Column[UInt8]` → `fill_null(value: int)`. It would require associated types or conditional types, which Python does not support.
 
-**Runtime alternative:** Enable `COLNADE_VALIDATE=1` or `set_validation(True)` and these mismatches are caught at expression construction time:
+**Runtime alternative:** Enable validation and these mismatches are caught at expression construction time:
 
 ```python
 import colnade
-colnade.set_validation(True)
+from colnade import ValidationLevel
+
+colnade.set_validation(ValidationLevel.STRUCTURAL)
+# or: COLNADE_VALIDATE=structural
 
 Users.age.fill_null(1.0)
 # TypeError: Type mismatch in Users.age.fill_null(): got float value 1.0,
 #            expected int for dtype UInt8
 ```
+
+Use `ValidationLevel.FULL` (or `COLNADE_VALIDATE=full`) to also enforce `Field()` value constraints at data boundaries. See [DataFrames: Validation](dataframes.md#validation) for details.
 
 ### Wrong-schema columns in expressions
 


### PR DESCRIPTION
## Summary

- Remove stale "coming soon" from README safety model
- Add `Field()` / `@schema_check` / `ValidationLevel` example to README Key Features
- Add value-level constraints row to comparison tables (README + docs/comparison.md)
- Add full Field() and @schema_check sections to docs/user-guide/schemas.md
- Update SchemaError docs to include `value_violations`
- Update type-checking.md runtime alternative to show `ValidationLevel` enum
- Fix unconditional validation claims in quick-start, basic-usage, and full-pipeline tutorials

## Files changed

| File | Change |
|------|--------|
| `README.md` | Remove "coming soon", add Field() section + comparison row |
| `docs/user-guide/schemas.md` | Add Field(), constraint table, @schema_check, SchemaError.value_violations |
| `docs/user-guide/type-checking.md` | Update runtime alternative to use ValidationLevel |
| `docs/comparison.md` | Add value-level constraints row |
| `docs/api/index.md` | Update module description |
| `docs/getting-started/quick-start.md` | Fix unconditional validation claim |
| `docs/tutorials/basic-usage.md` | Fix unconditional validation claim |
| `docs/tutorials/full-pipeline.md` | Fix unconditional validation claim |

## Test plan

- [x] `mkdocs build --strict` passes
- [x] All 951 tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)