### PR TITLE
Make comparison table more nuanced and honest

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,14 +246,19 @@ assignable to `Column[UInt8]`
 
 | Feature | Colnade | Pandera | StaticFrame | Patito | Narwhals |
 |---------|---------|---------|-------------|--------|----------|
-| Column refs checked statically | Yes | No | No | No | No |
-| Schema preserved through ops | Yes | Nominal only | No | No | No |
-| Works with existing engines | Yes | Yes | No | Polars only | Yes |
-| No plugins or code gen | Yes | No (mypy plugin) | Yes | Yes | Yes |
+| Column refs checked statically | Named attrs | No | Positional types | No | No |
+| Schema preserved through ops | Through ops¹ | At boundaries² | No | No | No |
+| Works with existing engines | Polars, Pandas, Dask | Pandas, Polars, others | Own engine | Polars only | Many engines |
+| No plugins or code gen | Yes | Requires mypy plugin | Yes | Yes | Yes |
 | Generic utility functions | Yes | No | No | No | No |
 | Struct/List typed access | Yes | No | No | No | No |
 | Lazy execution support | Yes | No | No | No | Yes |
-| Value-level constraints | Yes (`Field()`) | Yes (`Check`) | No | Yes (Pydantic) | No |
+| Value-level constraints | `Field()` | `Check` | No | Pydantic validators | No |
+
+¹ Schema-preserving ops (filter, sort, with_columns) retain `DataFrame[S]`. Schema-transforming ops (select, group_by) return `DataFrame[Any]` — use `cast_schema()` to bind.
+² Pandera's `@check_types` validates schemas at function boundaries via decorator, but column references within function bodies remain unchecked strings.
+
+See [Detailed Comparisons](https://colnade.com/comparison/) for a fuller discussion of tradeoffs.
 
 ## Documentation
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -4,37 +4,54 @@
 
 | Feature | Colnade | Pandera | StaticFrame | Patito | Narwhals |
 |---------|---------|---------|-------------|--------|----------|
-| Column refs checked statically | :white_check_mark: | :x: | :x: | :x: | :x: |
-| Schema preserved through ops | :white_check_mark: | Nominal only | :x: | :x: | :x: |
-| Works with existing engines | :white_check_mark: | :white_check_mark: | :x: | Polars only | :white_check_mark: |
-| No plugins or code gen | :white_check_mark: | :x: (mypy plugin) | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Generic utility functions | :white_check_mark: | :x: | :x: | :x: | :x: |
-| Struct/List typed access | :white_check_mark: | :x: | :x: | :x: | :x: |
-| Lazy execution support | :white_check_mark: | :x: | :x: | :x: | :white_check_mark: |
-| Value-level constraints | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | :x: |
+| Column refs checked statically | Named attrs | No | Positional types¹ | No | No |
+| Schema preserved through ops | Through ops² | At boundaries³ | No | No | No |
+| Works with existing engines | Polars, Pandas, Dask | Pandas, Polars, others | Own engine | Polars only | Many engines |
+| No plugins or code gen | Yes | Requires mypy plugin | Yes | Yes | Yes |
+| Generic utility functions | Yes | No | No | No | No |
+| Struct/List typed access | Yes | No | No | No | No |
+| Lazy execution support | Yes | No | No | No | Yes |
+| Value-level constraints | `Field()` | `Check` | No | Pydantic validators | No |
+
+¹ StaticFrame encodes column *types* positionally via `TypeVarTuple`, but column *names* are not part of the type signature.
+
+² Schema-preserving ops (filter, sort, with_columns) retain `DataFrame[S]`. Schema-transforming ops (select, group_by) return `DataFrame[Any]` — `cast_schema()` is needed to bind to the output schema and acts as a runtime trust boundary.
+
+³ Pandera's `@check_types` decorator validates schemas at function entry/exit, but column references within function bodies remain unchecked strings (`pa.Column("age")`).
 
 ## Detailed Comparisons
 
 ### Pandera
 
-Pandera provides runtime schema validation with a mypy plugin for basic static checking. However, its static checking is nominal only — it verifies that `DataFrame[A]` is passed where `DataFrame[A]` is expected, but cannot verify that the dataframe's contents match after transformation. Column references within function bodies remain unchecked strings.
+Pandera provides runtime schema validation with a mypy plugin for basic static checking. Its `@check_types` decorator validates that `DataFrame[InputSchema]` is passed where expected and that outputs match `DataFrame[OutputSchema]`, providing nominal schema tracking at function boundaries. However, column references within function bodies are unchecked strings — `pa.Column("misspelled")` passes the type checker.
 
-**Colnade's advantage:** Column references are class attributes (`Users.age` not `"age"`), so misspellings are caught at lint time. Schema types track through all operations, not just at function boundaries.
+**Colnade's approach:** Column references are class attributes (`Users.age` not `"age"`), so misspellings are caught at lint time. Schema types track through operations, not just at function boundaries. The tradeoff is that schema-transforming operations (select, group_by) erase the schema — `cast_schema()` is needed to re-bind, which Pandera's decorator approach avoids for simple input→output schemas.
 
 ### StaticFrame
 
-StaticFrame uses PEP 646 `TypeVarTuple` to encode column types as variadic generic parameters. Column types are positional, not named — there's no way to express "has a column called `age` of type `UInt8`." Schema transformations aren't tracked, and it requires adopting a niche DataFrame engine.
+StaticFrame uses PEP 646 `TypeVarTuple` to encode column types as variadic generic parameters. This gives static type checking of column *types* (you know the frame has an `int` column, a `str` column, etc.), but types are positional, not named — there's no way to express "has a column called `age` of type `UInt8`." It requires adopting StaticFrame's own DataFrame engine rather than working with Polars/Pandas.
 
-**Colnade's advantage:** Named columns with full type information. Works with existing engines (Polars, with more coming). Schema transformations are tracked through `cast_schema`.
+**Colnade's approach:** Named columns with full type information. Works with existing engines. The tradeoff is that Colnade requires a separate schema class definition, while StaticFrame infers types from data.
 
 ### Patito
 
-Patito provides Pydantic-style model classes that serve as Polars DataFrame schemas, with runtime validation. Clean API design, but purely runtime validation — `pl.col("misspelled")` passes the type checker.
+Patito provides Pydantic-style model classes that serve as Polars DataFrame schemas, with runtime validation including Pydantic's built-in validators for value constraints. Clean API design, and its model-based approach is similar to Colnade's schema pattern.
 
-**Colnade's advantage:** Static checking of all column references, not just runtime validation. Same schema-as-model pattern, but with compile-time safety.
+**Colnade's approach:** Static checking of all column references, not just runtime validation. Same schema-as-model pattern with similar value constraints (`Field()` vs Pydantic validators), but with compile-time safety for column references. Patito is Polars-only; Colnade supports multiple backends.
 
 ### Narwhals
 
-Narwhals is a lightweight compatibility layer providing a Polars-like API across multiple backends. It solves "write once, run on any engine" but provides no schema typing or static safety.
+Narwhals is a lightweight compatibility layer providing a Polars-like API across multiple backends (Polars, Pandas, cuDF, Modin, etc.). It solves "write once, run on any engine" but provides no schema typing or static safety.
 
-**Colnade's advantage:** Full static type safety for column references and schema transformations. Colnade complements the cross-engine approach rather than competing with it.
+**Colnade's approach:** Full static type safety for column references and schema transformations. Narwhals has broader engine support. The two libraries solve different problems and could potentially complement each other.
+
+## What Colnade does not do
+
+For transparency, here are things Colnade's type system cannot catch statically:
+
+- **Schema-transforming output types** — `select()` and `group_by().agg()` return `DataFrame[Any]`; `cast_schema()` binds to the output schema at runtime. A type checker plugin could theoretically infer the output schema, but this would couple Colnade to specific type checkers.
+- **Cross-schema expression misuse** — `df.filter(Orders.amount > 100)` on a `DataFrame[Users]` is not caught statically (column descriptors lack a schema type parameter). Enable runtime validation to catch this.
+- **Literal value types** — `Users.age + "hello"` is not caught (Python lacks type-level functions to map `Column[UInt8]` → operator overloads that only accept `int`).
+- **Method availability by dtype** — `Users.name.sum()` is not caught (requires self-narrowing support in type checkers).
+
+See [Type Checker Integration](user-guide/type-checking.md) for the full list of what is and isn't checked.


### PR DESCRIPTION
## Summary

Closes #81. Replaces binary yes/no comparison table values with descriptive terms and adds transparency about Colnade's limitations.

- Replace checkmarks with descriptive terms (e.g., "Named attrs", "Positional types", "At boundaries")
- Add numbered footnotes explaining `cast_schema()` trust boundary, Pandera's decorator approach, StaticFrame's positional types
- Reframe "advantage" headings as "approach" to acknowledge tradeoffs honestly
- Add "What Colnade does not do" section listing static safety boundaries
- Add link to detailed comparison page from README

## Test plan

- [x] `mkdocs build --strict` passes
- [x] ruff check/format passes
- [x] README table renders correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)