### PR TITLE
docs: be explicit about static safety boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ output = result.cast_schema(UserSummary)
 
 Colnade catches errors at three levels:
 
-1. **In your editor** — misspelled columns, type mismatches, and schema violations are flagged by your type checker (`ty`, `pyright`, `mypy`) before code runs
+1. **In your editor** — misspelled columns, schema mismatches at function boundaries, and nullability violations are flagged by your type checker (`ty`, `pyright`, `mypy`) before code runs
 2. **At data boundaries** — runtime validation ensures files and external data match your schemas (columns, types, nullability)
 3. **On your data values** — `Field()` constraints validate domain invariants like ranges, patterns, and uniqueness
+
+**Where static safety ends:** Static checking covers column references and schema-preserving operations (`filter`, `sort`, `with_columns`). Schema-transforming operations (`select`, `group_by`) return `DataFrame[Any]` — `cast_schema()` re-binds to a named schema and is a runtime trust boundary. No type checker plugin is needed, but this is a deliberate tradeoff: plugins could theoretically infer output schemas at the cost of type-checker coupling and maintenance burden. See [Type Checker Integration](https://colnade.com/user-guide/type-checking/) for the full list of what is and isn't checked.
 
 ## Key Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,9 +54,11 @@ Works with [ty](https://github.com/astral-sh/ty), mypy, and pyright. No plugins,
 
 ## Errors Caught at Three Levels
 
-1. **In your editor** — misspelled columns, type mismatches, and schema violations are flagged by your type checker before code runs
+1. **In your editor** — misspelled columns, schema mismatches at function boundaries, and nullability violations are flagged by your type checker before code runs
 2. **At data boundaries** — runtime validation ensures files and external data match your schemas (columns, types, nullability)
 3. **On your data values** — `Field()` constraints validate domain invariants like ranges, patterns, and uniqueness
+
+**Where static safety ends:** Static checking covers column references and schema-preserving operations (`filter`, `sort`, `with_columns`). Schema-transforming operations (`select`, `group_by`) return `DataFrame[Any]` — use `cast_schema()` to re-bind to a named schema at runtime. See [Type Checker Integration](user-guide/type-checking.md) for the full list of what is and isn't checked statically.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary

- Adds "Where static safety ends" paragraph to both README and docs landing page
- Clarifies that schema-transforming operations (`select`, `group_by`) return `DataFrame[Any]` and `cast_schema()` is the runtime trust boundary
- Links to the Type Checker Integration page for full details on what is/isn't checked statically
- Updates level 1 wording from "type mismatches" to more specific "schema mismatches at function boundaries, and nullability violations"

Closes #84

## Test plan

- [x] `mkdocs build --strict` passes
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)