### PR TITLE
Add error showcase SVG from real ty output

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,36 +228,9 @@ Colnade adds < 5% overhead for typical Polars operations and < 5% for single Pan
 
 Colnade catches real errors at lint time. Here are actual error messages from `ty`:
 
-### Misspelled column name
-
-```python
-x = Users.agee
-```
-```
-error[unresolved-attribute]: Class `Users` has no attribute `agee`
-```
-
-### Schema mismatch at function boundary
-
-```python
-df: DataFrame[Users] = read_parquet("users.parquet", Users)
-wrong: DataFrame[Orders] = df
-```
-```
-error[invalid-assignment]: Object of type `DataFrame[Users]` is not assignable
-to `DataFrame[Orders]`
-```
-
-### Nullability mismatch in mapped_from
-
-```python
-class Bad(Schema):
-    age: Column[UInt8] = mapped_from(Users.age)  # Users.age is Column[UInt8 | None]
-```
-```
-error[invalid-assignment]: Object of type `Column[UInt8 | None]` is not
-assignable to `Column[UInt8]`
-```
+<p align="center">
+  <img src="docs/assets/error-showcase.svg" alt="ty catching Colnade type errors — misspelled column, schema mismatch, nullability mismatch" width="800">
+</p>
 
 ## Comparison with Existing Solutions
 

--- a/docs/assets/error-showcase.svg
+++ b/docs/assets/error-showcase.svg
@@ -1,0 +1,228 @@
+<svg class="rich-terminal" viewBox="0 0 1116 1050.4" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2474034992-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2474034992-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2474034992-r1 { fill: #c5c8c6 }
+.terminal-2474034992-r2 { fill: #c5c8c6;font-weight: bold }
+.terminal-2474034992-r3 { fill: #cc555a;font-weight: bold }
+.terminal-2474034992-r4 { fill: #68a0b3 }
+.terminal-2474034992-r5 { fill: #608ab1 }
+.terminal-2474034992-r6 { fill: #68a0b3;font-weight: bold }
+.terminal-2474034992-r7 { fill: #cc555a }
+.terminal-2474034992-r8 { fill: #868887 }
+.terminal-2474034992-r9 { fill: #98729f;font-weight: bold }
+.terminal-2474034992-r10 { fill: #98a84b }
+.terminal-2474034992-r11 { fill: #d0b344 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2474034992-clip-terminal">
+      <rect x="0" y="0" width="1097.0" height="999.4" />
+    </clipPath>
+    <clipPath id="terminal-2474034992-line-0">
+    <rect x="0" y="1.5" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-1">
+    <rect x="0" y="25.9" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-2">
+    <rect x="0" y="50.3" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-3">
+    <rect x="0" y="74.7" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-4">
+    <rect x="0" y="99.1" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-5">
+    <rect x="0" y="123.5" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-6">
+    <rect x="0" y="147.9" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-7">
+    <rect x="0" y="172.3" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-8">
+    <rect x="0" y="196.7" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-9">
+    <rect x="0" y="221.1" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-10">
+    <rect x="0" y="245.5" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-11">
+    <rect x="0" y="269.9" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-12">
+    <rect x="0" y="294.3" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-13">
+    <rect x="0" y="318.7" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-14">
+    <rect x="0" y="343.1" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-15">
+    <rect x="0" y="367.5" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-16">
+    <rect x="0" y="391.9" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-17">
+    <rect x="0" y="416.3" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-18">
+    <rect x="0" y="440.7" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-19">
+    <rect x="0" y="465.1" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-20">
+    <rect x="0" y="489.5" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-21">
+    <rect x="0" y="513.9" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-22">
+    <rect x="0" y="538.3" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-23">
+    <rect x="0" y="562.7" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-24">
+    <rect x="0" y="587.1" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-25">
+    <rect x="0" y="611.5" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-26">
+    <rect x="0" y="635.9" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-27">
+    <rect x="0" y="660.3" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-28">
+    <rect x="0" y="684.7" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-29">
+    <rect x="0" y="709.1" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-30">
+    <rect x="0" y="733.5" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-31">
+    <rect x="0" y="757.9" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-32">
+    <rect x="0" y="782.3" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-33">
+    <rect x="0" y="806.7" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-34">
+    <rect x="0" y="831.1" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-35">
+    <rect x="0" y="855.5" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-36">
+    <rect x="0" y="879.9" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-37">
+    <rect x="0" y="904.3" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-38">
+    <rect x="0" y="928.7" width="1098" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2474034992-line-39">
+    <rect x="0" y="953.1" width="1098" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1114" height="1048.4" rx="8"/><text class="terminal-2474034992-title" fill="#c5c8c6" text-anchor="middle" x="557" y="27">ty&#160;catching&#160;Colnade&#160;type&#160;errors</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2474034992-clip-terminal)">
+    
+    <g class="terminal-2474034992-matrix">
+    <text class="terminal-2474034992-r1" x="1098" y="20" textLength="12.2" clip-path="url(#terminal-2474034992-line-0)">
+</text><text class="terminal-2474034992-r2" x="0" y="44.4" textLength="366" clip-path="url(#terminal-2474034992-line-1)">&#160;&#160;$&#160;ty&#160;check&#160;error_showcase.py</text><text class="terminal-2474034992-r1" x="1098" y="44.4" textLength="12.2" clip-path="url(#terminal-2474034992-line-1)">
+</text><text class="terminal-2474034992-r1" x="1098" y="68.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-2)">
+</text><text class="terminal-2474034992-r3" x="0" y="93.2" textLength="329.4" clip-path="url(#terminal-2474034992-line-3)">error[unresolved-attribute]</text><text class="terminal-2474034992-r2" x="329.4" y="93.2" textLength="475.8" clip-path="url(#terminal-2474034992-line-3)">:&#160;Class&#160;`Users`&#160;has&#160;no&#160;attribute&#160;`naem`</text><text class="terminal-2474034992-r1" x="1098" y="93.2" textLength="12.2" clip-path="url(#terminal-2474034992-line-3)">
+</text><text class="terminal-2474034992-r4" x="0" y="117.6" textLength="439.2" clip-path="url(#terminal-2474034992-line-4)">&#160;&#160;--&gt;&#160;scripts/error_showcase.py:24:5</text><text class="terminal-2474034992-r1" x="1098" y="117.6" textLength="12.2" clip-path="url(#terminal-2474034992-line-4)">
+</text><text class="terminal-2474034992-r5" x="0" y="142" textLength="48.8" clip-path="url(#terminal-2474034992-line-5)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r1" x="1098" y="142" textLength="12.2" clip-path="url(#terminal-2474034992-line-5)">
+</text><text class="terminal-2474034992-r6" x="0" y="166.4" textLength="24.4" clip-path="url(#terminal-2474034992-line-6)">22</text><text class="terminal-2474034992-r1" x="24.4" y="166.4" textLength="183" clip-path="url(#terminal-2474034992-line-6)">&#160;|&#160;#&#160;---&#160;Error&#160;</text><text class="terminal-2474034992-r6" x="207.4" y="166.4" textLength="12.2" clip-path="url(#terminal-2474034992-line-6)">1</text><text class="terminal-2474034992-r1" x="219.6" y="166.4" textLength="341.6" clip-path="url(#terminal-2474034992-line-6)">:&#160;Misspelled&#160;column&#160;name&#160;---</text><text class="terminal-2474034992-r1" x="1098" y="166.4" textLength="12.2" clip-path="url(#terminal-2474034992-line-6)">
+</text><text class="terminal-2474034992-r6" x="0" y="190.8" textLength="24.4" clip-path="url(#terminal-2474034992-line-7)">23</text><text class="terminal-2474034992-r1" x="24.4" y="190.8" textLength="24.4" clip-path="url(#terminal-2474034992-line-7)">&#160;|</text><text class="terminal-2474034992-r1" x="1098" y="190.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-7)">
+</text><text class="terminal-2474034992-r6" x="0" y="215.2" textLength="24.4" clip-path="url(#terminal-2474034992-line-8)">24</text><text class="terminal-2474034992-r1" x="24.4" y="215.2" textLength="207.4" clip-path="url(#terminal-2474034992-line-8)">&#160;|&#160;x&#160;=&#160;Users.naem</text><text class="terminal-2474034992-r1" x="1098" y="215.2" textLength="12.2" clip-path="url(#terminal-2474034992-line-8)">
+</text><text class="terminal-2474034992-r5" x="0" y="239.6" textLength="48.8" clip-path="url(#terminal-2474034992-line-9)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r7" x="48.8" y="239.6" textLength="183" clip-path="url(#terminal-2474034992-line-9)">&#160;&#160;&#160;&#160;&#160;^^^^^^^^^^</text><text class="terminal-2474034992-r1" x="1098" y="239.6" textLength="12.2" clip-path="url(#terminal-2474034992-line-9)">
+</text><text class="terminal-2474034992-r5" x="0" y="264" textLength="48.8" clip-path="url(#terminal-2474034992-line-10)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r1" x="1098" y="264" textLength="12.2" clip-path="url(#terminal-2474034992-line-10)">
+</text><text class="terminal-2474034992-r8" x="0" y="288.4" textLength="671" clip-path="url(#terminal-2474034992-line-11)">info:&#160;rule&#160;`unresolved-attribute`&#160;is&#160;enabled&#160;by&#160;default</text><text class="terminal-2474034992-r1" x="1098" y="288.4" textLength="12.2" clip-path="url(#terminal-2474034992-line-11)">
+</text><text class="terminal-2474034992-r1" x="1098" y="312.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-12)">
+</text><text class="terminal-2474034992-r3" x="0" y="337.2" textLength="305" clip-path="url(#terminal-2474034992-line-13)">error[invalid-assignment]</text><text class="terminal-2474034992-r2" x="305" y="337.2" textLength="695.4" clip-path="url(#terminal-2474034992-line-13)">:&#160;Object&#160;of&#160;type&#160;`DataFrame[Users]`&#160;is&#160;not&#160;assignable&#160;to&#160;</text><text class="terminal-2474034992-r1" x="1098" y="337.2" textLength="12.2" clip-path="url(#terminal-2474034992-line-13)">
+</text><text class="terminal-2474034992-r2" x="0" y="361.6" textLength="231.8" clip-path="url(#terminal-2474034992-line-14)">`DataFrame[Orders]`</text><text class="terminal-2474034992-r1" x="1098" y="361.6" textLength="12.2" clip-path="url(#terminal-2474034992-line-14)">
+</text><text class="terminal-2474034992-r4" x="0" y="386" textLength="439.2" clip-path="url(#terminal-2474034992-line-15)">&#160;&#160;--&gt;&#160;scripts/error_showcase.py:30:8</text><text class="terminal-2474034992-r1" x="1098" y="386" textLength="12.2" clip-path="url(#terminal-2474034992-line-15)">
+</text><text class="terminal-2474034992-r5" x="0" y="410.4" textLength="48.8" clip-path="url(#terminal-2474034992-line-16)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r1" x="1098" y="410.4" textLength="12.2" clip-path="url(#terminal-2474034992-line-16)">
+</text><text class="terminal-2474034992-r6" x="0" y="434.8" textLength="24.4" clip-path="url(#terminal-2474034992-line-17)">29</text><text class="terminal-2474034992-r1" x="24.4" y="434.8" textLength="195.2" clip-path="url(#terminal-2474034992-line-17)">&#160;|&#160;df:&#160;DataFrame</text><text class="terminal-2474034992-r2" x="219.6" y="434.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-17)">[</text><text class="terminal-2474034992-r1" x="231.8" y="434.8" textLength="61" clip-path="url(#terminal-2474034992-line-17)">Users</text><text class="terminal-2474034992-r2" x="292.8" y="434.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-17)">]</text><text class="terminal-2474034992-r1" x="305" y="434.8" textLength="36.6" clip-path="url(#terminal-2474034992-line-17)">&#160;=&#160;</text><text class="terminal-2474034992-r9" x="341.6" y="434.8" textLength="146.4" clip-path="url(#terminal-2474034992-line-17)">read_parquet</text><text class="terminal-2474034992-r2" x="488" y="434.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-17)">(</text><text class="terminal-2474034992-r10" x="500.2" y="434.8" textLength="183" clip-path="url(#terminal-2474034992-line-17)">&quot;users.parquet&quot;</text><text class="terminal-2474034992-r1" x="683.2" y="434.8" textLength="85.4" clip-path="url(#terminal-2474034992-line-17)">,&#160;Users</text><text class="terminal-2474034992-r2" x="768.6" y="434.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-17)">)</text><text class="terminal-2474034992-r1" x="1098" y="434.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-17)">
+</text><text class="terminal-2474034992-r6" x="0" y="459.2" textLength="24.4" clip-path="url(#terminal-2474034992-line-18)">30</text><text class="terminal-2474034992-r1" x="24.4" y="459.2" textLength="231.8" clip-path="url(#terminal-2474034992-line-18)">&#160;|&#160;wrong:&#160;DataFrame</text><text class="terminal-2474034992-r2" x="256.2" y="459.2" textLength="12.2" clip-path="url(#terminal-2474034992-line-18)">[</text><text class="terminal-2474034992-r1" x="268.4" y="459.2" textLength="73.2" clip-path="url(#terminal-2474034992-line-18)">Orders</text><text class="terminal-2474034992-r2" x="341.6" y="459.2" textLength="12.2" clip-path="url(#terminal-2474034992-line-18)">]</text><text class="terminal-2474034992-r1" x="353.8" y="459.2" textLength="61" clip-path="url(#terminal-2474034992-line-18)">&#160;=&#160;df</text><text class="terminal-2474034992-r1" x="1098" y="459.2" textLength="12.2" clip-path="url(#terminal-2474034992-line-18)">
+</text><text class="terminal-2474034992-r5" x="0" y="483.6" textLength="48.8" clip-path="url(#terminal-2474034992-line-19)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r7" x="48.8" y="483.6" textLength="927.2" clip-path="url(#terminal-2474034992-line-19)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;-----------------&#160;&#160;&#160;^^&#160;Incompatible&#160;value&#160;of&#160;type&#160;`DataFrame[Users]`</text><text class="terminal-2474034992-r1" x="1098" y="483.6" textLength="12.2" clip-path="url(#terminal-2474034992-line-19)">
+</text><text class="terminal-2474034992-r5" x="0" y="508" textLength="48.8" clip-path="url(#terminal-2474034992-line-20)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r1" x="48.8" y="508" textLength="109.8" clip-path="url(#terminal-2474034992-line-20)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;|</text><text class="terminal-2474034992-r1" x="1098" y="508" textLength="12.2" clip-path="url(#terminal-2474034992-line-20)">
+</text><text class="terminal-2474034992-r5" x="0" y="532.4" textLength="48.8" clip-path="url(#terminal-2474034992-line-21)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r11" x="48.8" y="532.4" textLength="256.2" clip-path="url(#terminal-2474034992-line-21)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Declared&#160;type</text><text class="terminal-2474034992-r1" x="1098" y="532.4" textLength="12.2" clip-path="url(#terminal-2474034992-line-21)">
+</text><text class="terminal-2474034992-r5" x="0" y="556.8" textLength="48.8" clip-path="url(#terminal-2474034992-line-22)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r1" x="1098" y="556.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-22)">
+</text><text class="terminal-2474034992-r8" x="0" y="581.2" textLength="646.6" clip-path="url(#terminal-2474034992-line-23)">info:&#160;rule&#160;`invalid-assignment`&#160;is&#160;enabled&#160;by&#160;default</text><text class="terminal-2474034992-r1" x="1098" y="581.2" textLength="12.2" clip-path="url(#terminal-2474034992-line-23)">
+</text><text class="terminal-2474034992-r1" x="1098" y="605.6" textLength="12.2" clip-path="url(#terminal-2474034992-line-24)">
+</text><text class="terminal-2474034992-r3" x="0" y="630" textLength="305" clip-path="url(#terminal-2474034992-line-25)">error[invalid-assignment]</text><text class="terminal-2474034992-r2" x="305" y="630" textLength="756.4" clip-path="url(#terminal-2474034992-line-25)">:&#160;Object&#160;of&#160;type&#160;`Column[UInt64&#160;|&#160;None]`&#160;is&#160;not&#160;assignable&#160;to&#160;</text><text class="terminal-2474034992-r1" x="1098" y="630" textLength="12.2" clip-path="url(#terminal-2474034992-line-25)">
+</text><text class="terminal-2474034992-r2" x="0" y="654.4" textLength="195.2" clip-path="url(#terminal-2474034992-line-26)">`Column[UInt64]`</text><text class="terminal-2474034992-r1" x="1098" y="654.4" textLength="12.2" clip-path="url(#terminal-2474034992-line-26)">
+</text><text class="terminal-2474034992-r4" x="0" y="678.8" textLength="451.4" clip-path="url(#terminal-2474034992-line-27)">&#160;&#160;--&gt;&#160;scripts/error_showcase.py:40:10</text><text class="terminal-2474034992-r1" x="1098" y="678.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-27)">
+</text><text class="terminal-2474034992-r5" x="0" y="703.2" textLength="48.8" clip-path="url(#terminal-2474034992-line-28)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r1" x="1098" y="703.2" textLength="12.2" clip-path="url(#terminal-2474034992-line-28)">
+</text><text class="terminal-2474034992-r6" x="0" y="727.6" textLength="24.4" clip-path="url(#terminal-2474034992-line-29)">39</text><text class="terminal-2474034992-r1" x="24.4" y="727.6" textLength="109.8" clip-path="url(#terminal-2474034992-line-29)">&#160;|&#160;class&#160;</text><text class="terminal-2474034992-r9" x="134.2" y="727.6" textLength="36.6" clip-path="url(#terminal-2474034992-line-29)">Bad</text><text class="terminal-2474034992-r2" x="170.8" y="727.6" textLength="12.2" clip-path="url(#terminal-2474034992-line-29)">(</text><text class="terminal-2474034992-r1" x="183" y="727.6" textLength="73.2" clip-path="url(#terminal-2474034992-line-29)">Schema</text><text class="terminal-2474034992-r2" x="256.2" y="727.6" textLength="12.2" clip-path="url(#terminal-2474034992-line-29)">)</text><text class="terminal-2474034992-r1" x="268.4" y="727.6" textLength="12.2" clip-path="url(#terminal-2474034992-line-29)">:</text><text class="terminal-2474034992-r1" x="1098" y="727.6" textLength="12.2" clip-path="url(#terminal-2474034992-line-29)">
+</text><text class="terminal-2474034992-r6" x="0" y="752" textLength="24.4" clip-path="url(#terminal-2474034992-line-30)">40</text><text class="terminal-2474034992-r1" x="24.4" y="752" textLength="219.6" clip-path="url(#terminal-2474034992-line-30)">&#160;|&#160;&#160;&#160;&#160;&#160;age:&#160;Column</text><text class="terminal-2474034992-r2" x="244" y="752" textLength="12.2" clip-path="url(#terminal-2474034992-line-30)">[</text><text class="terminal-2474034992-r1" x="256.2" y="752" textLength="73.2" clip-path="url(#terminal-2474034992-line-30)">UInt64</text><text class="terminal-2474034992-r2" x="329.4" y="752" textLength="12.2" clip-path="url(#terminal-2474034992-line-30)">]</text><text class="terminal-2474034992-r1" x="341.6" y="752" textLength="36.6" clip-path="url(#terminal-2474034992-line-30)">&#160;=&#160;</text><text class="terminal-2474034992-r9" x="378.2" y="752" textLength="134.2" clip-path="url(#terminal-2474034992-line-30)">mapped_from</text><text class="terminal-2474034992-r2" x="512.4" y="752" textLength="12.2" clip-path="url(#terminal-2474034992-line-30)">(</text><text class="terminal-2474034992-r1" x="524.6" y="752" textLength="219.6" clip-path="url(#terminal-2474034992-line-30)">NullableSource.age</text><text class="terminal-2474034992-r2" x="744.2" y="752" textLength="12.2" clip-path="url(#terminal-2474034992-line-30)">)</text><text class="terminal-2474034992-r1" x="1098" y="752" textLength="12.2" clip-path="url(#terminal-2474034992-line-30)">
+</text><text class="terminal-2474034992-r5" x="0" y="776.4" textLength="48.8" clip-path="url(#terminal-2474034992-line-31)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r7" x="48.8" y="776.4" textLength="1049.2" clip-path="url(#terminal-2474034992-line-31)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;--------------&#160;&#160;&#160;^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^&#160;Incompatible&#160;value&#160;of&#160;type&#160;</text><text class="terminal-2474034992-r1" x="1098" y="776.4" textLength="12.2" clip-path="url(#terminal-2474034992-line-31)">
+</text><text class="terminal-2474034992-r7" x="0" y="800.8" textLength="280.6" clip-path="url(#terminal-2474034992-line-32)">`Column[UInt64&#160;|&#160;None]`</text><text class="terminal-2474034992-r1" x="1098" y="800.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-32)">
+</text><text class="terminal-2474034992-r5" x="0" y="825.2" textLength="48.8" clip-path="url(#terminal-2474034992-line-33)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r1" x="48.8" y="825.2" textLength="134.2" clip-path="url(#terminal-2474034992-line-33)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;|</text><text class="terminal-2474034992-r1" x="1098" y="825.2" textLength="12.2" clip-path="url(#terminal-2474034992-line-33)">
+</text><text class="terminal-2474034992-r5" x="0" y="849.6" textLength="48.8" clip-path="url(#terminal-2474034992-line-34)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r11" x="48.8" y="849.6" textLength="280.6" clip-path="url(#terminal-2474034992-line-34)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Declared&#160;type</text><text class="terminal-2474034992-r1" x="1098" y="849.6" textLength="12.2" clip-path="url(#terminal-2474034992-line-34)">
+</text><text class="terminal-2474034992-r5" x="0" y="874" textLength="48.8" clip-path="url(#terminal-2474034992-line-35)">&#160;&#160;&#160;|</text><text class="terminal-2474034992-r1" x="1098" y="874" textLength="12.2" clip-path="url(#terminal-2474034992-line-35)">
+</text><text class="terminal-2474034992-r8" x="0" y="898.4" textLength="646.6" clip-path="url(#terminal-2474034992-line-36)">info:&#160;rule&#160;`invalid-assignment`&#160;is&#160;enabled&#160;by&#160;default</text><text class="terminal-2474034992-r1" x="1098" y="898.4" textLength="12.2" clip-path="url(#terminal-2474034992-line-36)">
+</text><text class="terminal-2474034992-r1" x="1098" y="922.8" textLength="12.2" clip-path="url(#terminal-2474034992-line-37)">
+</text><text class="terminal-2474034992-r1" x="1098" y="947.2" textLength="12.2" clip-path="url(#terminal-2474034992-line-38)">
+</text><text class="terminal-2474034992-r3" x="0" y="971.6" textLength="231.8" clip-path="url(#terminal-2474034992-line-39)">Found&#160;3&#160;diagnostics</text><text class="terminal-2474034992-r1" x="1098" y="971.6" textLength="12.2" clip-path="url(#terminal-2474034992-line-39)">
+</text><text class="terminal-2474034992-r1" x="1098" y="996" textLength="12.2" clip-path="url(#terminal-2474034992-line-40)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,8 @@ Works with [ty](https://github.com/astral-sh/ty), mypy, and pyright. No plugins,
 2. **At data boundaries** — runtime validation ensures files and external data match your schemas (columns, types, nullability) and that expressions reference columns from the correct schema
 3. **On your data values** — `Field()` constraints validate domain invariants like ranges, patterns, and uniqueness
 
+![ty catching Colnade type errors](assets/error-showcase.svg)
+
 **Where static safety ends:** Static checking covers column references and schema-preserving operations (`filter`, `sort`, `with_columns`). Schema-transforming operations (`select`, `group_by`) return `DataFrame[Any]` — use `cast_schema()` to re-bind to a named schema at runtime. See [Type Checker Integration](user-guide/type-checking.md) for the full list of what is and isn't checked statically.
 
 ## Key Features

--- a/scripts/error_showcase.py
+++ b/scripts/error_showcase.py
@@ -1,0 +1,41 @@
+"""Intentional type errors for the error showcase screenshot."""
+
+from colnade import Column, DataFrame, Float64, Schema, UInt64, Utf8, mapped_from
+from colnade_polars import read_parquet
+
+# --- Schema definitions ---
+
+
+class Users(Schema):
+    id: Column[UInt64]
+    name: Column[Utf8]
+    age: Column[UInt64]
+    score: Column[Float64]
+
+
+class Orders(Schema):
+    id: Column[UInt64]
+    user_id: Column[UInt64]
+    amount: Column[Float64]
+
+
+# --- Error 1: Misspelled column name ---
+
+x = Users.naem
+
+
+# --- Error 2: Schema mismatch at function boundary ---
+
+df: DataFrame[Users] = read_parquet("users.parquet", Users)
+wrong: DataFrame[Orders] = df
+
+
+# --- Error 3: Nullability mismatch in mapped_from ---
+
+
+class NullableSource(Schema):
+    age: Column[UInt64 | None]
+
+
+class Bad(Schema):
+    age: Column[UInt64] = mapped_from(NullableSource.age)

--- a/scripts/generate_error_screenshot.py
+++ b/scripts/generate_error_screenshot.py
@@ -1,0 +1,81 @@
+"""Generate an SVG screenshot of ty catching type errors in Colnade schemas."""
+
+import subprocess
+import sys
+
+from rich.console import Console
+from rich.text import Text
+
+
+def main():
+    # Run ty check and capture output
+    result = subprocess.run(
+        [sys.executable, "-m", "ty", "check", "scripts/error_showcase.py"],
+        capture_output=True,
+        text=True,
+    )
+    raw = result.stderr or result.stdout
+
+    # Create a recording console
+    console = Console(record=True, width=90, force_terminal=True)
+
+    # Print a header
+    console.print()
+    console.print("  $ ty check error_showcase.py", style="bold white")
+    console.print()
+
+    # Parse and render the ty output with colors
+    for line in raw.splitlines():
+        if line.startswith("error["):
+            # Error header line - red and bold
+            bracket_end = line.index("]") + 1
+            tag = line[:bracket_end]
+            rest = line[bracket_end:]
+            text = Text()
+            text.append(tag, style="bold red")
+            text.append(rest, style="bold white")
+            console.print(text)
+        elif line.strip().startswith("-->"):
+            # File location - blue
+            console.print(Text(line, style="cyan"))
+        elif line.strip().startswith("|"):
+            parts = line.split("|", 1)
+            if len(parts) == 2:
+                prefix = parts[0] + "|"
+                content = parts[1]
+                text = Text()
+                text.append(prefix, style="blue")
+                if "^^" in content:
+                    # Underline markers - red
+                    text.append(content, style="red")
+                elif "--" in content or "Incompatible" in content or "Declared" in content:
+                    # Annotation lines - yellow
+                    text.append(content, style="yellow")
+                else:
+                    # Code lines
+                    text.append(content, style="white")
+                console.print(text)
+        elif line.startswith("info:"):
+            console.print(Text(line, style="dim"))
+        elif line.startswith("Found"):
+            console.print()
+            console.print(Text(line, style="bold red"))
+        elif line == "":
+            console.print()
+        else:
+            console.print(line)
+
+    console.print()
+
+    # Export as SVG
+    svg = console.export_svg(title="ty catching Colnade type errors")
+
+    output_path = "docs/assets/error-showcase.svg"
+    with open(output_path, "w") as f:
+        f.write(svg)
+
+    print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `scripts/error_showcase.py` with three intentional type errors (misspelled column, schema mismatch, nullability mismatch)
- Add `scripts/generate_error_screenshot.py` that runs `ty check` and captures colorized output as SVG via `rich`
- Generate `docs/assets/error-showcase.svg` — terminal screenshot with syntax highlighting and macOS-style chrome
- Replace text-based error showcase in README with the SVG image
- Add the SVG to docs landing page under "Errors Caught at Three Levels"

Regenerate with: `uv run python scripts/generate_error_screenshot.py`

## Test plan
- [x] `uv run mkdocs build --strict` — docs build cleanly with the SVG
- [x] `uv run ruff check .` — no lint errors
- [x] `scripts/error_showcase.py` is not in `tests/typing/` so ty CI won't check it

🤖 Generated with [Claude Code](https://claude.com/claude-code)