### PR TITLE
Fix Codecov token and use built-in documentation label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - run: uv run pytest tests/ --cov=colnade --cov=colnade_polars --cov=colnade_pandas --cov=colnade_dask --cov-report=xml --cov-fail-under=80
       - uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           fail_ci_if_error: false
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Issues are the coordination mechanism for all work — both internal and externa
 | `triage` | Needs maintainer review — not yet confirmed |
 | `approved` | Confirmed worth doing, ready for someone to pick up |
 | `good first issue` | Scoped and newcomer-friendly |
-| `bug` / `feature` / `docs` | Type labels (combine with triage/approved) |
+| `bug` / `feature` / `documentation` | Type labels (combine with triage/approved) |
 
 ### Triage process
 
@@ -59,7 +59,7 @@ Issues are the coordination mechanism for all work — both internal and externa
 When filing issues, include:
 - Clear title describing the desired outcome
 - Enough context for someone else to understand and implement
-- Type label (`bug`, `feature`, `docs`)
+- Type label (`bug`, `feature`, `documentation`)
 - `approved` label for internal issues
 
 ### PRs


### PR DESCRIPTION
## Summary
- Add `token: ${{ secrets.CODECOV_TOKEN }}` to codecov-action (required for v5)
- Replace custom `docs` label with GitHub's built-in `documentation` label in CLAUDE.md

Follow-up to PR #94 — these fixes were pushed after that PR was merged.

## Setup
After merging, add the `CODECOV_TOKEN` secret: Settings > Secrets and variables > Actions > New repository secret. Get the token from your Codecov dashboard after enabling the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)