### PR TITLE
Redesign docs homepage with hero section and feature grid

### DIFF
--- a/docs/assets/stylesheets/home.css
+++ b/docs/assets/stylesheets/home.css
@@ -1,0 +1,149 @@
+/* ---------------------------------------------------------------------------
+   Hero section (rendered by docs/overrides/home.html)
+   --------------------------------------------------------------------------- */
+
+.colnade-hero {
+  padding: 4rem 1rem 3rem;
+  background: linear-gradient(135deg, var(--md-primary-fg-color), #1a237e);
+  color: white;
+  text-align: center;
+}
+
+[data-md-color-scheme="slate"] .colnade-hero {
+  background: linear-gradient(135deg, #283593, #0d1117);
+}
+
+.colnade-hero__content {
+  max-width: 48rem;
+  margin: 0 auto;
+}
+
+.colnade-hero h1 {
+  font-size: 2.4rem;
+  font-weight: 700;
+  margin: 0 0 1rem;
+  color: white;
+  line-height: 1.2;
+}
+
+.colnade-hero__tagline {
+  font-size: 1.15rem;
+  opacity: 0.92;
+  margin: 0 0 1.5rem;
+  line-height: 1.6;
+}
+
+.colnade-hero__tagline code {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  font-size: 0.95em;
+}
+
+.colnade-hero__buttons {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+
+.colnade-hero__buttons .md-button {
+  color: white;
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+.colnade-hero__buttons .md-button--primary {
+  background-color: white;
+  color: var(--md-primary-fg-color);
+  border-color: white;
+}
+
+.colnade-hero__buttons .md-button--primary:hover {
+  background-color: rgba(255, 255, 255, 0.9);
+}
+
+.colnade-hero__buttons .md-button:hover {
+  border-color: white;
+}
+
+.colnade-hero__meta {
+  font-size: 0.85rem;
+  opacity: 0.7;
+  margin: 0;
+}
+
+/* ---------------------------------------------------------------------------
+   Before / After comparison
+   --------------------------------------------------------------------------- */
+
+.compare-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin: 1.5rem 0 2.5rem;
+}
+
+@media (max-width: 768px) {
+  .compare-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.compare-grid .compare-col h3 {
+  margin-top: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.8;
+}
+
+/* ---------------------------------------------------------------------------
+   Feature grid
+   --------------------------------------------------------------------------- */
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+  margin: 1.5rem 0 2.5rem;
+}
+
+@media (max-width: 960px) {
+  .feature-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.feature-card {
+  padding: 1.25rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  transition: box-shadow 0.2s;
+}
+
+.feature-card:hover {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+[data-md-color-scheme="slate"] .feature-card:hover {
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+}
+
+.feature-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.feature-card p {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.8;
+  line-height: 1.5;
+}
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,90 @@
-# Colnade
+---
+title: Colnade
+template: home.html
+hide:
+  - navigation
+  - toc
+---
 
-**Catch DataFrame column errors before your code runs.**
+<div class="compare-grid" markdown>
+<div class="compare-col" markdown>
 
-Colnade replaces string-based column references (`pl.col("age")`) with typed descriptors (`Users.age`), so column misspellings, type mismatches, and schema violations are caught by your type checker — not in production.
+### Without type safety
 
-Works with [ty](https://github.com/astral-sh/ty), mypy, and pyright. No plugins, no code generation. Supports Polars, Pandas, and Dask.
+```python
+import polars as pl
 
-[Get Started](getting-started/installation.md){ .md-button .md-button--primary }
-[Tutorials](tutorials/basic-usage.md){ .md-button }
+# Typo silently produces wrong results
+df.filter(pl.col("naem") == "Alice")
+
+# Wrong column from wrong table — no error
+df.select(pl.col("amount"))  # amount is on orders, not users
+```
+
+</div>
+<div class="compare-col" markdown>
+
+### With Colnade
+
+```python
+from colnade_polars import read_parquet
+
+# Typo caught by type checker instantly
+df.filter(Users.naem == "Alice")  # error: no attribute 'naem'
+
+# Schema mismatch caught at function boundaries
+process_orders(users_df)  # error: expected DataFrame[Orders]
+```
+
+</div>
+</div>
+
+---
+
+<div class="feature-grid" markdown>
+<div class="feature-card" markdown>
+
+### Type-safe columns
+
+`Users.naem` is a type error, not a runtime crash. Column references are class attributes checked by your editor.
+
+</div>
+<div class="feature-card" markdown>
+
+### Schema preserved
+
+`filter`, `sort`, `with_columns` return `DataFrame[S]`. The type parameter flows through your entire pipeline.
+
+</div>
+<div class="feature-card" markdown>
+
+### Three validation levels
+
+**Off** for zero overhead. **Structural** checks columns and types. **Full** adds value constraints like ranges, patterns, and uniqueness.
+
+</div>
+<div class="feature-card" markdown>
+
+### Backend agnostic
+
+Write once, run on **Polars**, **Pandas**, or **Dask**. Same schema, same expressions, same type safety.
+
+</div>
+<div class="feature-card" markdown>
+
+### Generic functions
+
+`def f(df: DataFrame[S]) -> DataFrame[S]` works with any schema. Build reusable utilities without losing type information.
+
+</div>
+<div class="feature-card" markdown>
+
+### No plugins or codegen
+
+Works with `ty`, `mypy`, and `pyright` out of the box. Standard Python type annotations, nothing extra to install.
+
+</div>
+</div>
 
 ---
 
@@ -52,23 +129,10 @@ Works with [ty](https://github.com/astral-sh/ty), mypy, and pyright. No plugins,
 
 ---
 
-## Errors Caught at Three Levels
-
-1. **In your editor** — misspelled columns, schema mismatches at function boundaries, and nullability violations are flagged by your type checker before code runs
-2. **At data boundaries** — runtime validation ensures files and external data match your schemas (columns, types, nullability) and that expressions reference columns from the correct schema
-3. **On your data values** — `Field()` constraints validate domain invariants like ranges, patterns, and uniqueness
-
-![ty catching Colnade type errors](assets/error-showcase.svg)
-
-**Where static safety ends:** Static checking covers column references and schema-preserving operations (`filter`, `sort`, `with_columns`). Schema-transforming operations (`select`, `group_by`) return `DataFrame[Any]` — use `cast_schema()` to re-bind to a named schema at runtime. See [Type Checker Integration](user-guide/type-checking.md) for the full list of what is and isn't checked statically.
-
-## Key Features
-
-- **Type-safe column references** — `Users.naem` is a type error, not a runtime crash
-- **Schema-preserving operations** — `filter`, `sort`, `with_columns` preserve `DataFrame[S]`
-- **Typed expressions** — `Users.age > 18` produces `Expr[Bool]`, `Users.score * 2` produces `Expr[Float64]`
-- **Runtime validation** — `df.validate()` checks columns, types, and nullability; auto-validate at data boundaries with a single toggle
-- **Backend agnostic** — works with Polars, Pandas, and Dask
-- **Generic utility functions** — write `def f(df: DataFrame[S]) -> DataFrame[S]` that works with any schema
-- **Struct and List support** — typed access to nested data structures
-- **No plugins or codegen** — works with standard type checkers out of the box
+<p style="text-align: center; opacity: 0.7; font-size: 0.9rem;">
+<a href="getting-started/installation/">Installation</a> &middot;
+<a href="user-guide/core-concepts/">User Guide</a> &middot;
+<a href="tutorials/basic-usage/">Tutorials</a> &middot;
+<a href="api/">API Reference</a> &middot;
+<a href="comparison/">Comparison</a>
+</p>

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -1,0 +1,27 @@
+{% extends "main.html" %}
+
+{% block tabs %}
+  {{ super() }}
+  <section class="colnade-hero">
+    <div class="colnade-hero__content md-grid">
+      <h1>Catch DataFrame bugs<br>before your code runs</h1>
+      <p class="colnade-hero__tagline">
+        Replace <code>pl.col("age")</code> with <code>Users.age</code>.
+        Your type checker catches the rest.
+      </p>
+      <div class="colnade-hero__buttons">
+        <a href="{{ page.next_page.url | url }}" class="md-button md-button--primary">Get Started</a>
+        <a href="tutorials/basic-usage/" class="md-button">Tutorials</a>
+      </div>
+      <p class="colnade-hero__meta">
+        Works with <strong>ty</strong>, <strong>mypy</strong>, and <strong>pyright</strong>.
+        Supports <strong>Polars</strong>, <strong>Pandas</strong>, and <strong>Dask</strong>.
+        No plugins. No codegen.
+      </p>
+    </div>
+  </section>
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ repo_name: jwde/colnade
 
 theme:
   name: material
+  custom_dir: docs/overrides
   palette:
     - scheme: default
       primary: indigo
@@ -49,6 +50,9 @@ plugins:
             merge_init_into_class: true
             signature_crossrefs: true
             docstring_style: google
+
+extra_css:
+  - assets/stylesheets/home.css
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
## Summary

- Redesigns the docs homepage from flat markdown into a visually structured landing page
- Adds a hero section with gradient background, tagline, and CTA buttons via Material for MkDocs template override
- Adds a before/after code comparison showing string-based columns vs typed Colnade columns
- Replaces the bullet-list features with a responsive 6-card feature grid
- Removes the detailed comparison table from homepage (still available at `/comparison/`)
- Responsive: 3-column grid on desktop, 2 on tablet, 1 on mobile

### New files
- `docs/overrides/home.html` — custom template extending `main.html` with hero block
- `docs/assets/stylesheets/home.css` — hero, comparison grid, and feature card styles

### Also filed
- #99 — PyPI trusted publisher registration needed for colnade-pandas and colnade-dask (manual admin action)

## Test plan

- [x] `mkdocs build --strict` passes
- [x] API docs check passes
- [x] Hero only renders on homepage, not other pages
- [x] All 1255 tests pass
- [ ] Visual check: `mkdocs serve` and review at localhost:8000

🤖 Generated with [Claude Code](https://claude.com/claude-code)