### PR TITLE
Restore from_dict and from_rows to Dask backend

### DIFF
--- a/colnade-dask/src/colnade_dask/__init__.py
+++ b/colnade-dask/src/colnade_dask/__init__.py
@@ -6,6 +6,8 @@ __version__: str = _version("colnade-dask")
 
 from colnade_dask.adapter import DaskBackend
 from colnade_dask.io import (
+    from_dict,
+    from_rows,
     scan_csv,
     scan_parquet,
     write_csv,
@@ -14,6 +16,8 @@ from colnade_dask.io import (
 
 __all__ = [
     "DaskBackend",
+    "from_dict",
+    "from_rows",
     "scan_csv",
     "scan_parquet",
     "write_csv",

--- a/docs/api/dask.md
+++ b/docs/api/dask.md
@@ -1,10 +1,16 @@
 # colnade_dask
 
-Dask backend adapter and I/O functions.
+Dask backend adapter, construction functions, and I/O functions.
 
 ## DaskBackend
 
 ::: colnade_dask.adapter.DaskBackend
+
+## Construction Functions
+
+::: colnade_dask.io.from_dict
+
+::: colnade_dask.io.from_rows
 
 ## I/O Functions
 


### PR DESCRIPTION
## Summary

- **Restore `from_dict` and `from_rows`** to `colnade-dask`. These were incorrectly removed in #106 along with the eager I/O functions. Unlike `read_parquet`/`read_csv`, these construct DataFrames from in-memory data — the lazy-only rationale doesn't apply.
- Restore API docs and test coverage for both functions.

## Test plan

- [x] All 1257 tests pass
- [x] Added `TestDaskFromDict`, `TestDaskFromRows`, `TestDaskFromDictErrors` test classes
- [x] Added Dask case to `TestFromRowsErrors`
- [x] Docs build with `mkdocs build --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)