### PR TITLE
Add std, var, n_unique aggregations to Pandas and Dask

### DIFF
--- a/colnade-dask/src/colnade_dask/adapter.py
+++ b/colnade-dask/src/colnade_dask/adapter.py
@@ -55,6 +55,9 @@ _AGG_MAP: dict[str, str] = {
     "min": "min",
     "max": "max",
     "count": "count",
+    "std": "std",
+    "var": "var",
+    "n_unique": "nunique",
     "first": "first",
     "last": "last",
 }

--- a/colnade-pandas/src/colnade_pandas/adapter.py
+++ b/colnade-pandas/src/colnade_pandas/adapter.py
@@ -54,6 +54,9 @@ _AGG_MAP: dict[str, str] = {
     "min": "min",
     "max": "max",
     "count": "count",
+    "std": "std",
+    "var": "var",
+    "n_unique": "nunique",
     "first": "first",
     "last": "last",
 }

--- a/tests/integration/test_dask_execution.py
+++ b/tests/integration/test_dask_execution.py
@@ -220,6 +220,47 @@ class TestSelect:
 # ---------------------------------------------------------------------------
 
 
+class TestAggFunctions:
+    def test_std(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1, 2, 3], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice", "Bob", "Charlie"], dtype=pd.StringDtype()),
+                "age": pd.array([30, 25, 35], dtype=pd.UInt64Dtype()),
+            }
+        )
+        ddf = dd.from_pandas(data, npartitions=2)
+        df = DataFrame(_data=ddf, _schema=Users, _backend=DaskBackend())
+        result = df.agg(Users.age.std().alias(Users.age))
+        assert result._data.compute()["age"].iloc[0] > 0
+
+    def test_var(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1, 2, 3], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice", "Bob", "Charlie"], dtype=pd.StringDtype()),
+                "age": pd.array([30, 25, 35], dtype=pd.UInt64Dtype()),
+            }
+        )
+        ddf = dd.from_pandas(data, npartitions=2)
+        df = DataFrame(_data=ddf, _schema=Users, _backend=DaskBackend())
+        result = df.agg(Users.age.var().alias(Users.age))
+        assert result._data.compute()["age"].iloc[0] > 0
+
+    def test_n_unique(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1, 2, 3], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice", "Alice", "Bob"], dtype=pd.StringDtype()),
+                "age": pd.array([30, 25, 35], dtype=pd.UInt64Dtype()),
+            }
+        )
+        ddf = dd.from_pandas(data, npartitions=2)
+        df = DataFrame(_data=ddf, _schema=Users, _backend=DaskBackend())
+        result = df.agg(Users.name.n_unique().alias(Users.name))
+        assert result._data.compute()["name"].iloc[0] == 2
+
+
 class TestGroupByAgg:
     def test_group_by_sum(self) -> None:
         data = pd.DataFrame(

--- a/tests/integration/test_pandas_execution.py
+++ b/tests/integration/test_pandas_execution.py
@@ -212,6 +212,44 @@ class TestSelect:
 # ---------------------------------------------------------------------------
 
 
+class TestAggFunctions:
+    def test_std(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1, 2, 3], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice", "Bob", "Charlie"], dtype=pd.StringDtype()),
+                "age": pd.array([30, 25, 35], dtype=pd.UInt64Dtype()),
+            }
+        )
+        df = DataFrame(_data=data, _schema=Users, _backend=PandasBackend())
+        result = df.agg(Users.age.std().alias(Users.age))
+        assert result._data["age"].iloc[0] > 0
+
+    def test_var(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1, 2, 3], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice", "Bob", "Charlie"], dtype=pd.StringDtype()),
+                "age": pd.array([30, 25, 35], dtype=pd.UInt64Dtype()),
+            }
+        )
+        df = DataFrame(_data=data, _schema=Users, _backend=PandasBackend())
+        result = df.agg(Users.age.var().alias(Users.age))
+        assert result._data["age"].iloc[0] > 0
+
+    def test_n_unique(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1, 2, 3], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice", "Alice", "Bob"], dtype=pd.StringDtype()),
+                "age": pd.array([30, 25, 35], dtype=pd.UInt64Dtype()),
+            }
+        )
+        df = DataFrame(_data=data, _schema=Users, _backend=PandasBackend())
+        result = df.agg(Users.name.n_unique().alias(Users.name))
+        assert result._data["name"].iloc[0] == 2
+
+
 class TestGroupByAgg:
     def test_group_by_sum(self) -> None:
         data = pd.DataFrame(

--- a/tests/integration/test_polars_execution.py
+++ b/tests/integration/test_polars_execution.py
@@ -212,6 +212,44 @@ class TestSelect:
 # ---------------------------------------------------------------------------
 
 
+class TestAggFunctions:
+    def test_std(self) -> None:
+        data = pl.DataFrame(
+            {
+                "id": pl.Series([1, 2, 3], dtype=pl.UInt64),
+                "name": ["Alice", "Bob", "Charlie"],
+                "age": pl.Series([30, 25, 35], dtype=pl.UInt64),
+            }
+        )
+        df = DataFrame(_data=data, _schema=Users, _backend=PolarsBackend())
+        result = df.agg(Users.age.std().alias(Users.age))
+        assert result._data["age"][0] > 0
+
+    def test_var(self) -> None:
+        data = pl.DataFrame(
+            {
+                "id": pl.Series([1, 2, 3], dtype=pl.UInt64),
+                "name": ["Alice", "Bob", "Charlie"],
+                "age": pl.Series([30, 25, 35], dtype=pl.UInt64),
+            }
+        )
+        df = DataFrame(_data=data, _schema=Users, _backend=PolarsBackend())
+        result = df.agg(Users.age.var().alias(Users.age))
+        assert result._data["age"][0] > 0
+
+    def test_n_unique(self) -> None:
+        data = pl.DataFrame(
+            {
+                "id": pl.Series([1, 2, 3], dtype=pl.UInt64),
+                "name": ["Alice", "Alice", "Bob"],
+                "age": pl.Series([30, 25, 35], dtype=pl.UInt64),
+            }
+        )
+        df = DataFrame(_data=data, _schema=Users, _backend=PolarsBackend())
+        result = df.agg(Users.name.n_unique().alias(Users.name))
+        assert result._data["name"][0] == 2
+
+
 class TestGroupByAgg:
     def test_group_by_sum(self) -> None:
         data = pl.DataFrame(


### PR DESCRIPTION
## Summary

- Add `std`, `var`, and `n_unique` to the `_AGG_MAP` in both Pandas and Dask adapters. These aggregations were defined in the expression system but missing from the backend translation maps, causing `ValueError: Unsupported aggregation` at runtime.
- `n_unique` maps to `nunique` (the Pandas/Dask method name).
- Adds `TestAggFunctions` with `test_std`, `test_var`, `test_n_unique` to all three backend execution test suites.

Closes #110

## Test plan

- [x] All 1273 tests pass
- [x] New tests cover std/var/n_unique on Polars, Pandas, and Dask

🤖 Generated with [Claude Code](https://claude.com/claude-code)