### PR TITLE
Add height and __len__ to LazyFrame

### DIFF
--- a/src/colnade/dataframe.py
+++ b/src/colnade/dataframe.py
@@ -630,6 +630,18 @@ class LazyFrame(Generic[S]):
             raise TypeError(msg)
         return len(self._schema._columns)
 
+    @property
+    def height(self) -> int:
+        """Return the number of rows.
+
+        This triggers computation on lazy backends (e.g. Dask).
+        """
+        return _require_backend(self._backend).row_count(self._data)
+
+    def __len__(self) -> int:
+        """Return the number of rows."""
+        return self.height
+
     # --- Schema-preserving operations (return LazyFrame[S]) ---
 
     def filter(self, predicate: Expr[Bool]) -> LazyFrame[S]:

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -513,16 +513,21 @@ class TestLazyFrameIntrospection:
         with pytest.raises(TypeError, match="width is not available"):
             lf.width  # noqa: B018
 
+    def test_height_returns_row_count(self) -> None:
+        lf = self.lf if hasattr(self, "lf") else LazyFrame(_schema=Users, _backend=_BACKEND)
+        assert isinstance(lf.height, int)
+
+    def test_len_returns_row_count(self) -> None:
+        lf = self.lf if hasattr(self, "lf") else LazyFrame(_schema=Users, _backend=_BACKEND)
+        assert isinstance(len(lf), int)
+
 
 # ---------------------------------------------------------------------------
-# LazyFrame restrictions (no height, shape, is_empty, __len__, iter_rows_as)
+# LazyFrame restrictions (no shape, is_empty, iter_rows_as)
 # ---------------------------------------------------------------------------
 
 
 class TestLazyFrameIntrospectionRestrictions:
-    def test_no_height(self) -> None:
-        assert not hasattr(LazyFrame, "height")
-
     def test_no_shape(self) -> None:
         assert not hasattr(LazyFrame, "shape")
 
@@ -531,11 +536,6 @@ class TestLazyFrameIntrospectionRestrictions:
 
     def test_no_iter_rows_as(self) -> None:
         assert not hasattr(LazyFrame, "iter_rows_as")
-
-    def test_no_len(self) -> None:
-        lf = LazyFrame(_schema=Users, _backend=_BACKEND)
-        with pytest.raises(TypeError):
-            len(lf)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `height` property and `__len__` to `LazyFrame` for parity with `DataFrame`. These trigger computation on lazy backends (e.g. Dask) as documented in the Dask user guide.
- Remove negative tests that asserted `LazyFrame` lacks `height` and `__len__`.

## Test plan

- [x] All 1273 tests pass
- [x] Added `test_height_returns_row_count` and `test_len_returns_row_count` to `TestLazyFrameIntrospection`
- [x] Updated restriction test class comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)