### PR TITLE
Add to_batches to LazyFrame

### DIFF
--- a/colnade-polars/src/colnade_polars/adapter.py
+++ b/colnade-polars/src/colnade_polars/adapter.py
@@ -506,6 +506,8 @@ class PolarsBackend:
         """Convert a Polars DataFrame to an iterator of Arrow RecordBatches."""
         import pyarrow as pa  # noqa: F811
 
+        if hasattr(source, "collect"):
+            source = source.collect()
         table: pa.Table = source.to_arrow()
         if batch_size is not None:
             yield from table.to_batches(max_chunksize=batch_size)

--- a/src/colnade/dataframe.py
+++ b/src/colnade/dataframe.py
@@ -642,6 +642,17 @@ class LazyFrame(Generic[S]):
         """Return the number of rows."""
         return self.height
 
+    def to_batches(self, batch_size: int | None = None) -> Iterator[ArrowBatch[S]]:
+        """Convert to an iterator of typed Arrow batches.
+
+        This triggers computation on lazy backends (e.g. Dask).
+        """
+        from colnade.arrow import ArrowBatch
+
+        backend = _require_backend(self._backend)
+        for raw_batch in backend.to_arrow_batches(self._data, batch_size):
+            yield ArrowBatch(_batch=raw_batch, _schema=self._schema)
+
     # --- Schema-preserving operations (return LazyFrame[S]) ---
 
     def filter(self, predicate: Expr[Bool]) -> LazyFrame[S]:

--- a/tests/integration/test_arrow_boundary.py
+++ b/tests/integration/test_arrow_boundary.py
@@ -77,6 +77,26 @@ class TestToBatches:
         assert all(b.num_rows == 1 for b in batches)
 
 
+class TestLazyFrameToBatches:
+    def test_returns_arrow_batches(self) -> None:
+        lf = _users_df().lazy()
+        batches = list(lf.to_batches())
+        assert len(batches) >= 1
+        assert all(isinstance(b, ArrowBatch) for b in batches)
+
+    def test_preserves_schema_type(self) -> None:
+        lf = _users_df().lazy()
+        batches = list(lf.to_batches())
+        for batch in batches:
+            assert batch.schema is Users
+
+    def test_total_rows_match(self) -> None:
+        lf = _users_df().lazy()
+        batches = list(lf.to_batches())
+        total = sum(b.num_rows for b in batches)
+        assert total == 3
+
+
 # ---------------------------------------------------------------------------
 # from_batches
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -407,7 +407,7 @@ class TestLazyFrame:
 
 
 # ---------------------------------------------------------------------------
-# LazyFrame restrictions (no sample, to_batches)
+# LazyFrame restrictions (no sample)
 # ---------------------------------------------------------------------------
 
 
@@ -415,8 +415,8 @@ class TestLazyFrameRestrictions:
     def test_no_sample(self) -> None:
         assert not hasattr(LazyFrame, "sample")
 
-    def test_no_to_batches(self) -> None:
-        assert not hasattr(LazyFrame, "to_batches")
+    def test_has_to_batches(self) -> None:
+        assert hasattr(LazyFrame, "to_batches")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `to_batches()` to `LazyFrame` for parity with `DataFrame`. Triggers computation on lazy backends (e.g. Dask), as documented in the Dask user guide.

## Test plan

- [x] All 1273 tests pass
- [x] Removed negative test asserting `to_batches` was absent
- [x] Added positive test verifying method exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)