### PR TITLE
ci: switch from Codecov to coverage-comment-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,17 +30,27 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
       - run: uv sync
-      - run: uv run pytest tests/ --cov=colnade --cov=colnade_polars --cov=colnade_pandas --cov=colnade_dask --cov-report=xml --cov-fail-under=95
-      - uses: codecov/codecov-action@v5
+      - run: uv run pytest tests/ --cov=colnade --cov=colnade_polars --cov=colnade_pandas --cov=colnade_dask --cov-fail-under=95
+      - name: Coverage comment
+        id: coverage_comment
+        uses: py-cov-action/python-coverage-comment-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
-          fail_ci_if_error: true
-          verbose: true
+          GITHUB_TOKEN: ${{ github.token }}
+          MINIMUM_GREEN: 95
+          MINIMUM_ORANGE: 80
+      - name: Store coverage comment artifact
+        uses: actions/upload-artifact@v4
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        with:
+          name: python-coverage-comment-action
+          path: python-coverage-comment-action.txt
 
   test-backend-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+name: Post coverage comment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  post-coverage-comment:
+    name: Post coverage comment
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      contents: write
+      actions: read
+    steps:
+      # DO NOT checkout here — security risk with workflow_run
+      # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/jwde/colnade/actions/workflows/ci.yml"><img src="https://github.com/jwde/colnade/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://codecov.io/gh/jwde/colnade"><img src="https://codecov.io/gh/jwde/colnade/graph/badge.svg" alt="codecov"></a>
+  <a href="https://htmlpreview.github.io/?https://github.com/jwde/colnade/blob/python-coverage-comment-action-data/htmlcov/index.html"><img src="https://raw.githubusercontent.com/jwde/colnade/python-coverage-comment-action-data/badge.svg" alt="Coverage"></a>
   <a href="https://pypi.org/project/colnade/"><img src="https://img.shields.io/pypi/v/colnade" alt="PyPI"></a>
   <a href="https://pypi.org/project/colnade/"><img src="https://img.shields.io/pypi/pyversions/colnade" alt="Python 3.10+"></a>
 </p>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        threshold: 0.5%
-    patch:
-      default:
-        target: 95%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ select = ["E", "F", "W", "I", "UP", "B", "SIM"]
 [tool.ruff.lint.isort]
 known-first-party = ["colnade", "colnade_polars", "colnade_pandas", "colnade_dask"]
 
+[tool.coverage.run]
+relative_files = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]


### PR DESCRIPTION
## Summary
- Replace Codecov with [python-coverage-comment-action](https://github.com/py-cov-action/python-coverage-comment-action) — zero external dependencies
- Badge stored on a branch in the repo (`python-coverage-comment-action-data`), no third-party service
- PR comments with coverage diffs posted via GitHub Actions
- Separate `coverage.yml` workflow handles fork PR comments securely

## Why
Codecov's backend stuck in broken state after repo erase/recreate — uploads succeed (HTTP 200) but processing never completes (`state: "started"`, `totals: null`). This is a [known recurring issue](https://github.com/codecov/codecov-action/issues/1787). Rather than waiting for Codecov support, switching to a tool with no external dependencies.

## Test plan
- [ ] CI coverage job passes
- [ ] After merge to main, `python-coverage-comment-action-data` branch is created with `badge.svg`
- [ ] Badge resolves in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)