### PR TITLE
Replace private attribute access with public API in examples

### DIFF
--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -52,9 +52,8 @@ with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
 # ---------------------------------------------------------------------------
 
 df = read_parquet(parquet_path, Users)
-print(f"Read {df._data.shape[0]} users")
-schema_name = df._schema.__name__ if df._schema else "None"
-print(f"Schema: {schema_name}")
+print(f"Read {len(df)} users")
+print(f"Schema: {df!r}")
 print()
 
 # ---------------------------------------------------------------------------
@@ -64,7 +63,7 @@ print()
 # Users.age is a Column[UInt64] descriptor — misspelling it is a type error
 adults = df.filter(Users.age >= 30)
 print("Users aged 30+:")
-print(adults._data)
+print(adults)
 print()
 
 # ---------------------------------------------------------------------------
@@ -73,7 +72,7 @@ print()
 
 by_score = df.sort(Users.score.desc())
 print("Users by score (descending):")
-print(by_score._data)
+print(by_score)
 print()
 
 # ---------------------------------------------------------------------------
@@ -82,7 +81,7 @@ print()
 
 doubled = df.with_columns((Users.score * 2).alias(Users.score))
 print("Doubled scores:")
-print(doubled._data)
+print(doubled)
 print()
 
 # ---------------------------------------------------------------------------
@@ -90,10 +89,8 @@ print()
 # ---------------------------------------------------------------------------
 
 summary = df.select(Users.name, Users.score).cast_schema(UserSummary)
-summary_name = summary._schema.__name__ if summary._schema else "None"
-print(f"Summary schema: {summary_name}")
-print(f"Summary columns: {summary._data.columns}")
-print(summary._data)
+print(f"Summary: {summary!r}")
+print(summary)
 print()
 
 # ---------------------------------------------------------------------------

--- a/examples/generic_functions.py
+++ b/examples/generic_functions.py
@@ -49,7 +49,7 @@ def drop_null_rows(df: DataFrame[S]) -> DataFrame[S]:
 
 def count_rows(df: DataFrame[S]) -> int:
     """Count rows in any typed DataFrame."""
-    return df._data.shape[0]
+    return len(df)
 
 
 # ---------------------------------------------------------------------------
@@ -83,13 +83,13 @@ products = from_rows(
 # first_n(users, 3) returns DataFrame[Users]
 top_users = first_n(users, 3)
 print(f"first_n(users, 3) -> {top_users!r}")
-print(top_users._data)
+print(top_users)
 print()
 
 # first_n(products, 2) returns DataFrame[Products]
 top_products = first_n(products, 2)
 print(f"first_n(products, 2) -> {top_products!r}")
-print(top_products._data)
+print(top_products)
 print()
 
 # count_rows works on both
@@ -100,6 +100,6 @@ print()
 # drop_null_rows preserves schema
 clean_users = drop_null_rows(users)
 print(f"drop_null_rows(users) -> {clean_users!r}")
-print(f"Rows: {clean_users._data.shape[0]}")
+print(f"Rows: {len(clean_users)}")
 
 print("\nDone!")

--- a/examples/joins.py
+++ b/examples/joins.py
@@ -56,10 +56,10 @@ orders = from_rows(
 )
 
 print("Users:")
-print(users._data)
+print(users)
 print()
 print("Orders:")
-print(orders._data)
+print(orders)
 print()
 
 # ---------------------------------------------------------------------------
@@ -68,10 +68,8 @@ print()
 
 # Users.id == Orders.user_id produces a JoinCondition (not BinOp)
 # because the columns belong to different schemas
-joined = users.join(orders, on=Users.id == Orders.user_id)  # type: ignore[invalid-argument-type]
-print(f"Join result type: {joined!r}")
-print(f"Rows after join: {joined._data.shape[0]}")
-print(joined._data)
+joined = users.join(orders, on=Users.id == Orders.user_id)
+print(f"Join result: {joined!r}")
 print()
 
 # ---------------------------------------------------------------------------
@@ -82,8 +80,7 @@ print()
 # Users.name → "user_name", Users.id → "user_id", amount matches by name
 result = joined.cast_schema(UserOrders)
 print(f"After cast_schema: {result!r}")
-print(f"Columns: {result._data.columns}")
-print(result._data)
+print(result)
 print()
 
 # ---------------------------------------------------------------------------
@@ -92,6 +89,6 @@ print()
 
 big_orders = joined.filter(Orders.amount >= 150).cast_schema(UserOrders)
 print("Big orders (amount >= 150):")
-print(big_orders._data)
+print(big_orders)
 
 print("\nDone!")

--- a/examples/nested_types.py
+++ b/examples/nested_types.py
@@ -45,7 +45,7 @@ df = from_dict(
     },
 )
 print("User profiles:")
-print(df._data)
+print(df)
 print()
 
 # ---------------------------------------------------------------------------
@@ -56,7 +56,7 @@ print()
 # UserProfile.address.field(Address.city) creates a StructFieldAccess node
 new_yorkers = df.filter(UserProfile.address.field(Address.city) == "New York")
 print("Users in New York:")
-print(new_yorkers._data)
+print(new_yorkers)
 print()
 
 # ---------------------------------------------------------------------------
@@ -66,24 +66,24 @@ print()
 # .list.len() — count elements in each list
 print("Tag counts:")
 tag_lengths = df.with_columns(UserProfile.tags.list.len().alias(UserProfile.tags))
-print(tag_lengths._data.select("name", "tags"))
+print(tag_lengths.select(UserProfile.name, UserProfile.tags))
 print()
 
 # .list.contains() — check if list contains a value
 python_users = df.filter(UserProfile.tags.list.contains("python"))
 print("Users with 'python' tag:")
-print(python_users._data.select("name", "tags"))
+print(python_users.select(UserProfile.name, UserProfile.tags))
 print()
 
 # .list.get() — get element by index
 first_tags = df.with_columns(UserProfile.tags.list.get(0).alias(UserProfile.tags))
 print("First tag per user:")
-print(first_tags._data.select("name", "tags"))
+print(first_tags.select(UserProfile.name, UserProfile.tags))
 print()
 
 # .list.sum() — sum list elements (for numeric lists)
 score_totals = df.with_columns(UserProfile.scores.list.sum().alias(UserProfile.scores))
 print("Total scores per user:")
-print(score_totals._data.select("name", "scores"))
+print(score_totals.select(UserProfile.name, UserProfile.scores))
 
 print("\nDone!")

--- a/examples/null_handling.py
+++ b/examples/null_handling.py
@@ -16,8 +16,8 @@ from colnade_polars import from_dict
 class Users(Schema):
     id: Column[UInt64]
     name: Column[Utf8]
-    age: Column[UInt64]
-    score: Column[Float64]
+    age: Column[UInt64 | None]
+    score: Column[Float64 | None]
 
 
 # ---------------------------------------------------------------------------
@@ -34,9 +34,7 @@ df = from_dict(
     },
 )
 print("Original data:")
-print(df._data)
-print(f"Age nulls: {df._data['age'].null_count()}")
-print(f"Score nulls: {df._data['score'].null_count()}")
+print(df)
 print()
 
 # ---------------------------------------------------------------------------
@@ -48,9 +46,7 @@ filled = df.with_columns(
     Users.score.fill_null(0.0).alias(Users.score),
 )
 print("After fill_null(0):")
-print(filled._data)
-print(f"Age nulls: {filled._data['age'].null_count()}")
-print(f"Score nulls: {filled._data['score'].null_count()}")
+print(filled)
 print()
 
 # ---------------------------------------------------------------------------
@@ -59,12 +55,12 @@ print()
 
 no_null_scores = df.drop_nulls(Users.score)
 print("After drop_nulls(Users.score):")
-print(no_null_scores._data)
+print(no_null_scores)
 print()
 
 no_nulls_at_all = df.drop_nulls(Users.age, Users.score)
 print("After drop_nulls(Users.age, Users.score):")
-print(no_nulls_at_all._data)
+print(no_nulls_at_all)
 print()
 
 # ---------------------------------------------------------------------------
@@ -73,12 +69,12 @@ print()
 
 null_scores = df.filter(Users.score.is_null())
 print("Rows with null scores:")
-print(null_scores._data)
+print(null_scores)
 print()
 
 valid_scores = df.filter(Users.score.is_not_null())
 print("Rows with non-null scores:")
-print(valid_scores._data)
+print(valid_scores)
 print()
 
 # ---------------------------------------------------------------------------
@@ -90,6 +86,6 @@ result = df.with_columns(
 ).filter(Users.score > 50)
 
 print("After fill_null(0.0) then filter(score > 50):")
-print(result._data)
+print(result)
 
 print("\nDone!")


### PR DESCRIPTION
## Summary
- Replace all `._data` and `._schema` accesses in examples with public API methods (`len()`, `print()`, `select()`, `repr()`)
- Fix `null_handling.py` schema to use `Column[T | None]` for nullable columns (was incorrectly using non-nullable types with null data)
- Fix `count_rows()` in `generic_functions.py` to use `len(df)` instead of `._data.shape[0]`

All examples verified to run correctly.

Closes #121, closes #122