### PR TITLE
Fix colnade-dask README to list actual exports

### DIFF
--- a/colnade-dask/README.md
+++ b/colnade-dask/README.md
@@ -26,9 +26,9 @@ result = lf.filter(Users.age > 25).sort(Users.score.desc()).collect()
 
 ## I/O Functions
 
-- `read_parquet` / `write_parquet` (eager)
-- `scan_parquet` / `scan_csv` (lazy)
-- `read_csv` / `write_csv`
+- `scan_parquet` / `scan_csv` (lazy reads)
+- `write_parquet` / `write_csv`
+- `from_dict` / `from_rows` (in-memory construction)
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- Remove `read_parquet` and `read_csv` from I/O functions list (removed in v0.5.3)
- Add `from_dict` and `from_rows` (restored in v0.5.4)
- List matches actual `__all__` exports

Closes #124