### PR TITLE
Fix README and comparison docs issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ class UserProfile(Schema):
 
 # Access nested data
 df.filter(UserProfile.address.field(Address.city) == "New York")
-df.with_columns(UserProfile.tags.list.len().alias(tag_count_col))
+df.with_columns(UserProfile.tags.list.len().alias(UserProfile.tags))
 ```
 
 ### Value-level constraints
@@ -203,7 +203,8 @@ class Users(Schema):
         return Users.age >= 18
 
 # Validate with df.validate() or auto-validate at the FULL level
-colnade.set_validation(ValidationLevel.FULL)
+from colnade import set_validation
+set_validation(ValidationLevel.FULL)
 ```
 
 ### Lazy execution
@@ -246,7 +247,7 @@ Colnade catches real errors at lint time. Here are actual error messages from `t
 | Column refs checked statically | Named attrs | No | Positional types | No | No |
 | Schema preserved through ops | Through ops¹ | At boundaries² | No | No | No |
 | Works with existing engines | Polars, Pandas, Dask | Pandas, Polars, others | Own engine | Polars only | Many engines |
-| No plugins or code gen | Yes | Requires mypy plugin | Yes | Yes | Yes |
+| No plugins or code gen | Yes | Optional mypy plugin | Yes | Yes | Yes |
 | Generic utility functions | Yes | No | No | No | No |
 | Struct/List typed access | Yes | No | No | No | No |
 | Lazy execution support | Yes | No | No | No | Yes |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -7,7 +7,7 @@
 | Column refs checked statically | Named attrs | No | Positional types¹ | No | No |
 | Schema preserved through ops | Through ops² | At boundaries³ | No | No | No |
 | Works with existing engines | Polars, Pandas, Dask | Pandas, Polars, others | Own engine | Polars only | Many engines |
-| No plugins or code gen | Yes | Requires mypy plugin | Yes | Yes | Yes |
+| No plugins or code gen | Yes | Optional mypy plugin | Yes | Yes | Yes |
 | Generic utility functions | Yes | No | No | No | No |
 | Struct/List typed access | Yes | No | No | No | No |
 | Lazy execution support | Yes | No | No | No | Yes |


### PR DESCRIPTION
## Summary
- Replace undefined `tag_count_col` variable with `UserProfile.tags` in README Struct/List example (#126)
- Fix `set_validation()` example to use `from colnade import set_validation` instead of bare `colnade.set_validation()` (#127)
- Change Pandera "Requires mypy plugin" to "Optional mypy plugin" in both README and comparison docs (#128)

Closes #126, closes #127, closes #128