### PR TITLE
Remove unused dead code and dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
 ]
-dependencies = [
-    "typing_extensions>=4.0",
-]
+dependencies = []
 
 [project.urls]
 Homepage = "https://colnade.com"

--- a/src/colnade/schema.py
+++ b/src/colnade/schema.py
@@ -45,11 +45,6 @@ _S2 = TypeVar("_S2")  # inner schema for Struct[_S2]
 _E = TypeVar("_E")  # element type for List[_E]
 
 # ---------------------------------------------------------------------------
-# Schema registry
-# ---------------------------------------------------------------------------
-
-_schema_registry: dict[str, type[Schema]] = {}
-
 # ---------------------------------------------------------------------------
 # _MappedFrom sentinel (for cast_schema resolution)
 # ---------------------------------------------------------------------------
@@ -733,10 +728,6 @@ class SchemaMeta(type(Protocol)):  # type(Protocol) is typing._ProtocolMeta (CPy
         # Generate Row dataclass for non-base schemas with columns
         if name != "Schema" and columns:
             cls.Row = _build_row_class(name, cls, columns)  # type: ignore[attr-defined]
-
-        # Register non-base schemas
-        if name != "Schema":
-            _schema_registry[name] = cls
 
         return cls
 

--- a/src/colnade/udf.py
+++ b/src/colnade/udf.py
@@ -1,1 +1,0 @@
-"""@udf decorator for typed batch UDFs."""

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -21,7 +21,6 @@ from colnade import (
     UInt64,
     Utf8,
 )
-from colnade.schema import _schema_registry
 
 # ---------------------------------------------------------------------------
 # Test fixture schemas
@@ -212,19 +211,6 @@ class TestEdgeCases:
 # ---------------------------------------------------------------------------
 # Schema registry
 # ---------------------------------------------------------------------------
-
-
-class TestSchemaRegistry:
-    def test_schemas_registered(self) -> None:
-        assert "Users" in _schema_registry
-        assert "EnrichedUsers" in _schema_registry
-        assert "Events" in _schema_registry
-
-    def test_schema_base_not_registered(self) -> None:
-        assert "Schema" not in _schema_registry
-
-    def test_registry_values_are_classes(self) -> None:
-        assert _schema_registry["Users"] is Users
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -181,11 +181,8 @@ wheels = [
 
 [[package]]
 name = "colnade"
-version = "0.5.4"
+version = "0.6.0"
 source = { editable = "." }
-dependencies = [
-    { name = "typing-extensions" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -203,7 +200,6 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "typing-extensions", specifier = ">=4.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -222,7 +218,7 @@ dev = [
 
 [[package]]
 name = "colnade-dask"
-version = "0.3.4"
+version = "0.3.6"
 source = { editable = "colnade-dask" }
 dependencies = [
     { name = "colnade" },
@@ -241,7 +237,7 @@ requires-dist = [
 
 [[package]]
 name = "colnade-pandas"
-version = "0.3.2"
+version = "0.3.4"
 source = { editable = "colnade-pandas" }
 dependencies = [
     { name = "colnade" },
@@ -259,7 +255,7 @@ requires-dist = [
 
 [[package]]
 name = "colnade-polars"
-version = "0.5.2"
+version = "0.5.4"
 source = { editable = "colnade-polars" }
 dependencies = [
     { name = "colnade" },


### PR DESCRIPTION
## Summary
- Remove `typing_extensions>=4.0` from dependencies — never imported anywhere (#132)
- Delete empty `udf.py` placeholder — no implementation, misleading (#133)
- Remove `_schema_registry` global dict — never read, causes silent name collisions and memory leaks (#135)

All 1276 tests pass (3 removed registry tests).

Closes #132, closes #133, closes #135