### PR TITLE
Fix LazyFrame docstring and docs comparison table

### DIFF
--- a/docs/user-guide/dataframes.md
+++ b/docs/user-guide/dataframes.md
@@ -50,7 +50,9 @@ df = read_parquet("users.parquet", Users)
 | | DataFrame | LazyFrame |
 |-|-----------|-----------|
 | Execution | Immediate (eager) | Deferred (lazy) |
-| `head()`, `tail()`, `sample()` | Available | Not available |
+| `head()`, `tail()` | Available | Available |
+| `height`, `len()` | Available | Available (triggers computation) |
+| `to_batches()` | Available | Available (triggers computation) |
 | `collect()` | N/A | Materializes to DataFrame |
 | Best for | Interactive work, small data | Optimized pipelines, large data |
 

--- a/src/colnade/dataframe.py
+++ b/src/colnade/dataframe.py
@@ -577,8 +577,7 @@ class DataFrame(Generic[S]):
 class LazyFrame(Generic[S]):
     """A typed, lazy query plan parameterized by a Schema.
 
-    Same operations as DataFrame except: no head(), tail(), sample(),
-    to_batches() (materialized-only ops). Use collect() to materialize.
+    Supports the same operations as DataFrame. Use collect() to materialize.
     """
 
     __slots__ = ("_data", "_schema", "_backend")


### PR DESCRIPTION
## Summary
- Fix LazyFrame class docstring (incorrectly said "no head(), tail(), to_batches()" — all exist)
- Update docs comparison table to show head/tail, height/len, and to_batches as available on LazyFrame

Closes #134