### PR TITLE
Fix __and__, __or__, __invert__ return types to Bool

### DIFF
--- a/src/colnade/expr.py
+++ b/src/colnade/expr.py
@@ -30,13 +30,13 @@ class Expr(Generic[DType]):
 
     # --- Logical operators (for chaining boolean expressions) ---
 
-    def __and__(self, other: Expr[Any]) -> BinOp[DType]:
+    def __and__(self, other: Expr[Any]) -> BinOp[Bool]:
         return BinOp(left=self, right=_wrap(other), op="&")
 
-    def __or__(self, other: Expr[Any]) -> BinOp[DType]:
+    def __or__(self, other: Expr[Any]) -> BinOp[Bool]:
         return BinOp(left=self, right=_wrap(other), op="|")
 
-    def __invert__(self) -> UnaryOp[DType]:
+    def __invert__(self) -> UnaryOp[Bool]:
         return UnaryOp(operand=self, op="~")
 
     # --- Comparison operators (for expression chaining) ---


### PR DESCRIPTION
## Summary
- `__and__` and `__or__` now return `BinOp[Bool]` instead of `BinOp[DType]`
- `__invert__` now returns `UnaryOp[Bool]` instead of `UnaryOp[DType]`

Logical operators always produce boolean results — preserving the input type parameter was a type safety gap.

Closes #137