### PR TITLE
Implement assert_non_null to actually raise on null values

### DIFF
--- a/colnade-pandas/src/colnade_pandas/adapter.py
+++ b/colnade-pandas/src/colnade_pandas/adapter.py
@@ -212,7 +212,18 @@ class PandasBackend:
             fill_fn = self._ensure_callable(self.translate_expr(expr.args[1]))
             return lambda df, _s=source_fn, _f=fill_fn: _s(df).fillna(_f(df))
         if name == "assert_non_null":
-            return self._ensure_callable(self.translate_expr(expr.args[0]))
+            source_fn = self._ensure_callable(self.translate_expr(expr.args[0]))
+
+            def _check_nulls(df: Any, _s: Any = source_fn) -> Any:
+                result = _s(df)
+                null_count = int(result.isna().sum())
+                if null_count > 0:
+                    raise ValueError(
+                        f"assert_non_null failed: column contains {null_count} null values"
+                    )
+                return result
+
+            return _check_nulls
 
         # Cast
         if name == "cast":

--- a/tests/integration/test_dask_coverage.py
+++ b/tests/integration/test_dask_coverage.py
@@ -611,6 +611,19 @@ class TestFunctionCallExecution:
         result = df.with_columns(Users.age.assert_non_null().alias(Users.age))
         assert result._data.compute()["age"].tolist() == [30, 25, 35, 28, 40]
 
+    def test_assert_non_null_raises_on_nulls(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1, 2], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice", "Bob"], dtype=pd.StringDtype()),
+                "age": pd.array([30, None], dtype=pd.UInt64Dtype()),
+                "score": pd.array([85.0, 92.5], dtype=pd.Float64Dtype()),
+            }
+        )
+        df = DataFrame(_data=dd.from_pandas(data, npartitions=1), _schema=Users, _backend=_backend)
+        with pytest.raises(ValueError, match="assert_non_null failed"):
+            df.with_columns(Users.age.assert_non_null().alias(Users.age))
+
     def test_cast(self) -> None:
         df = _users_ddf()
         result = df.with_columns(Users.age.cast(Float64).alias(Users.age))

--- a/tests/integration/test_pandas_coverage.py
+++ b/tests/integration/test_pandas_coverage.py
@@ -644,6 +644,19 @@ class TestFunctionCallExecution:
         result = df.with_columns(Users.age.assert_non_null().alias(Users.age))
         assert result._data["age"].tolist() == [30, 25, 35, 28, 40]
 
+    def test_assert_non_null_raises_on_nulls(self) -> None:
+        data = pd.DataFrame(
+            {
+                "id": pd.array([1, 2], dtype=pd.UInt64Dtype()),
+                "name": pd.array(["Alice", "Bob"], dtype=pd.StringDtype()),
+                "age": pd.array([30, None], dtype=pd.UInt64Dtype()),
+                "score": pd.array([85.0, 92.5], dtype=pd.Float64Dtype()),
+            }
+        )
+        df = DataFrame(_data=data, _schema=Users, _backend=_backend)
+        with pytest.raises(ValueError, match="assert_non_null failed"):
+            df.with_columns(Users.age.assert_non_null().alias(Users.age))
+
     def test_cast(self) -> None:
         df = _users_df()
         result = df.with_columns(Users.age.cast(Float64).alias(Users.age))

--- a/tests/unit/test_polars_expr_translation.py
+++ b/tests/unit/test_polars_expr_translation.py
@@ -428,6 +428,12 @@ class TestMiscFunctions:
         result = df.select(backend.translate_expr(expr)).to_series()
         assert result.to_list() == ["Alice", "Bob"]
 
+    def test_assert_non_null_raises_on_nulls(self) -> None:
+        expr = Users.name.assert_non_null()
+        df = pl.DataFrame({"name": ["Alice", None]})
+        with pytest.raises(ValueError, match="assert_non_null failed"):
+            df.select(backend.translate_expr(expr))
+
     def test_cast(self) -> None:
 
         expr = Users.age.cast(Float64)


### PR DESCRIPTION
## Summary
- All three backends previously treated `assert_non_null()` as a no-op
- Now raises `ValueError` when the column contains null values
- Polars uses `map_batches()`, Pandas/Dask wrap the source callable with a null check
- Added tests verifying the error is raised on all three backends

Closes #129