### PR TITLE
Fix str_contains to use literal matching on Polars

### DIFF
--- a/colnade-polars/src/colnade_polars/adapter.py
+++ b/colnade-polars/src/colnade_polars/adapter.py
@@ -113,7 +113,7 @@ class PolarsBackend:
         # String methods
         if name == "str_contains":
             source = self.translate_expr(expr.args[0])
-            return source.str.contains(expr.args[1])
+            return source.str.contains(expr.args[1], literal=True)
         if name == "str_starts_with":
             source = self.translate_expr(expr.args[0])
             return source.str.starts_with(expr.args[1])


### PR DESCRIPTION
## Summary
- Polars `str.contains()` defaults to regex matching, while Pandas/Dask used `regex=False` (literal)
- Added `literal=True` to the Polars adapter so all backends consistently use literal matching
- Pattern `"foo.bar"` now matches only `"foo.bar"`, not `"fooXbar"`, across all backends

Closes #130