### PR TITLE
Fix docs audit findings and add changelog date CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,5 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       - run: uv sync
       - run: uv run python scripts/check_api_docs.py
+      - run: uv run python scripts/check_changelog.py
       - run: uv run mkdocs build --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-02-11
+## [0.7.0] - 2026-02-24
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ uv run ruff format --check .
 uv run pytest tests/ -v
 uv run ty check tests/typing/ --error-on-warning
 uv run python scripts/check_api_docs.py
+uv run python scripts/check_changelog.py
 uv run mkdocs build --strict
 ```
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -12,7 +12,7 @@
 | Struct/List typed access | Yes | No | No | No | No |
 | Lazy execution support | Yes | No | No | No | Yes |
 | Value-level constraints | `Field()` | `Check` | No | Pydantic validators | No |
-| Maturity / ecosystem | New (v0.6) | Mature, large community | Mature | Small | Growing fast |
+| Maturity / ecosystem | New (v0.7) | Mature, large community | Mature | Small | Growing fast |
 | Engine breadth | 3 backends | 4+ backends | Own engine | 1 backend | 6+ backends |
 | select/group_by output typing | `DataFrame[Any]`⁴ | Decorator-checked | Positional types | No | No |
 

--- a/docs/tutorials/full-pipeline.md
+++ b/docs/tutorials/full-pipeline.md
@@ -90,7 +90,7 @@ revenue = (
 ```python
 from colnade_polars import write_parquet
 
-result = revenue.sort(UserRevenue.total_amount, descending=True)
+result = revenue.sort(UserRevenue.total_amount.desc())
 write_parquet(result, "user_revenue.parquet")
 ```
 

--- a/docs/user-guide/dataframes.md
+++ b/docs/user-guide/dataframes.md
@@ -226,6 +226,7 @@ Checks column existence, data types, and nullability constraints.
 Enable auto-validation at data boundaries:
 
 ```python
+import colnade
 from colnade import ValidationLevel
 
 colnade.set_validation(ValidationLevel.STRUCTURAL)  # or FULL

--- a/docs/user-guide/performance.md
+++ b/docs/user-guide/performance.md
@@ -10,7 +10,7 @@ Colnade's expression DSL builds an AST (abstract syntax tree) that gets translat
 - **Validation is not free**, but it's designed for development and CI, not production hot paths.
 
 <p align="center">
-  <img src="../assets/images/overhead-scaling.svg" alt="Pipeline overhead vs dataset size — both Polars and Pandas hover around 0%" width="600">
+  <img src="../assets/images/overhead-scaling.svg" alt="Pipeline overhead vs dataset size — Raw Polars and Colnade lines overlap completely" width="600">
 </p>
 
 ## Abstraction overhead by backend

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 import tempfile
 
 from colnade import Column, Float64, Schema, UInt64, Utf8
-from colnade_polars import from_rows, write_parquet
-from colnade_polars.io import read_parquet
+from colnade_polars import from_rows, read_parquet, write_parquet
 
 # ---------------------------------------------------------------------------
 # 1. Define schemas — typed column references, verified by the type checker

--- a/examples/full_pipeline.py
+++ b/examples/full_pipeline.py
@@ -10,8 +10,7 @@ import tempfile
 from pathlib import Path
 
 from colnade import Column, Float64, Schema, UInt64, Utf8, mapped_from
-from colnade_polars import from_dict, write_parquet
-from colnade_polars.io import read_parquet
+from colnade_polars import from_dict, read_parquet, write_parquet
 
 # ---------------------------------------------------------------------------
 # Schemas

--- a/scripts/check_changelog.py
+++ b/scripts/check_changelog.py
@@ -1,0 +1,50 @@
+"""Verify CHANGELOG.md dates are in descending chronological order.
+
+Prevents a recurring issue where release entries get the wrong date,
+making newer versions appear older than previous ones.
+
+    uv run python scripts/check_changelog.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+CHANGELOG = Path(__file__).resolve().parent.parent / "CHANGELOG.md"
+HEADING_RE = re.compile(r"^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})$")
+
+
+def main() -> int:
+    entries: list[tuple[str, date]] = []
+    for line in CHANGELOG.read_text().splitlines():
+        m = HEADING_RE.match(line)
+        if m:
+            entries.append((m.group(1), date.fromisoformat(m.group(2))))
+
+    if not entries:
+        print("ERROR: no versioned entries found in CHANGELOG.md")
+        return 1
+
+    errors = 0
+    for i in range(len(entries) - 1):
+        ver_a, date_a = entries[i]
+        ver_b, date_b = entries[i + 1]
+        if date_a < date_b:
+            print(
+                f"ERROR: v{ver_a} ({date_a}) is dated earlier than "
+                f"v{ver_b} ({date_b}) — dates must be in descending order"
+            )
+            errors += 1
+
+    if errors:
+        return 1
+
+    print(f"OK: {len(entries)} changelog entries in chronological order")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes all 10 issues from the documentation audit (#153).

**Permanent fix for recurring changelog date bug:**
- Added `scripts/check_changelog.py` — parses `## [version] - date` headings and verifies dates are in descending chronological order
- Added to CI pipeline and CLAUDE.md pre-commit checklist
- This bug has recurred twice (#123, #153); now CI will catch it

**Credibility fixes:**
- Fix CHANGELOG v0.7.0 date (was 2026-02-11, actually 2026-02-24)
- Fix comparison.md version v0.6 → v0.7
- Fix chart alt text to match actual chart content

**Broken code fixes:**
- Add missing `import colnade` in dataframes.md validation example
- Add `UserStats` schema definition to README aggregation example
- Add explanation of `mapped_from` in README joins example

**Polish:**
- Standardize example imports to `from colnade_polars import ...`
- Replace marketing-y performance language with concrete comparison
- Use idiomatic `.desc()` in full-pipeline tutorial
- Replace "runtime trust boundary" jargon with plain description

Closes #153

## Test plan

- [x] All 1248 tests pass
- [x] `check_changelog.py` passes (and would have caught the date bug)
- [x] `check_api_docs.py` passes
- [x] `mkdocs build --strict` passes
- [x] `ty check` passes
- [x] ruff lint + format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)