### PR TITLE
Fix docs audit round 2: factual errors and misleading examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">A statically type-safe DataFrame abstraction layer for Python.</p>
 
-Colnade replaces string-based column references (`pl.col("age")`) with typed descriptors (`Users.age`), so column misspellings, type mismatches, and schema violations are caught by your type checker — before your code runs.
+Colnade replaces string-based column references (`pl.col("age")`) with typed descriptors (`Users.age`), so column misspellings and type mismatches are caught by your type checker — before your code runs.
 
 Works with [ty](https://github.com/astral-sh/ty), mypy, and pyright. No plugins, no code generation.
 
@@ -186,10 +186,11 @@ class UserProfile(Schema):
     name: Column[Utf8]
     address: Column[Struct[Address]]
     tags: Column[List[Utf8]]
+    tag_count: Column[UInt32]
 
 # Access nested data
 df.filter(UserProfile.address.field(Address.city) == "New York")
-df.with_columns(UserProfile.tags.list.len().alias(UserProfile.tags))
+df.with_columns(UserProfile.tags.list.len().alias(UserProfile.tag_count))
 ```
 
 ### Value-level constraints

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -18,7 +18,7 @@
 
 ¹ StaticFrame encodes column *types* positionally via `TypeVarTuple`, but column *names* are not part of the type signature.
 
-² Schema-preserving ops (filter, sort, with_columns) retain `DataFrame[S]`. Schema-transforming ops (select, group_by) return `DataFrame[Any]` — `cast_schema()` is needed to bind to the output schema and acts as a runtime trust boundary.
+² Schema-preserving ops (filter, sort, with_columns) retain `DataFrame[S]`. Schema-transforming ops (select, group_by) return `DataFrame[Any]` — use `cast_schema()` to bind to the output schema, which validates column names and types at runtime.
 
 ³ Pandera's `@check_types` decorator validates schemas at function entry/exit, but column references within function bodies remain unchecked strings (`pa.Column("age")`).
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -46,13 +46,13 @@ All these operations return `DataFrame[Users]` — the schema type is preserved.
 
 ## 4. Select and bind to an output schema
 
+Operations like `filter` and `sort` keep all columns, so they preserve `DataFrame[Users]`. But `select` changes which columns exist, so it returns `DataFrame[Any]`. Use `cast_schema()` to bind the result to a new schema:
+
 ```python
 class UserSummary(Schema):
     name: Column[Utf8]
     score: Column[Float64]
 
-# select returns DataFrame[Any] — columns changed
-# cast_schema binds to the target schema
 summary = df.select(Users.name, Users.score).cast_schema(UserSummary)
 # summary is DataFrame[UserSummary]
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,10 @@ import polars as pl
 
 df = pl.read_parquet("users.parquet")
 
-# Typo — silently produces zero rows
+# Typo — crashes at runtime
 df.filter(pl.col("naem") == "Alice")
 
-# Wrong method on column — crashes at runtime
+# Wrong method — crashes at runtime
 df.select(pl.col("name").sum())
 ```
 
@@ -34,11 +34,11 @@ from myapp.schemas import Users
 
 df = read_parquet("users.parquet", Users)
 
-# Typo — caught by your type checker
+# Typo — caught in your editor
 df.filter(Users.naem == "Alice")  # error!
 
-# Wrong method on column — caught by your type checker
-df.select(Users.name.sum())  # error! sum() requires numeric
+# Wrong method — caught in your editor
+df.select(Users.name.sum())  # error!
 ```
 
 </div>

--- a/docs/tutorials/nested-types.md
+++ b/docs/tutorials/nested-types.md
@@ -43,25 +43,23 @@ df.filter(UserProfile.address.field(Address.zip_code).is_not_null())
 Access list methods via the `.list` property:
 
 ```python
-# Count elements in each list
-tag_counts = df.with_columns(
-    UserProfile.tags.list.len().alias(UserProfile.tags)
-)
-
 # Check if list contains a value
 python_users = df.filter(
     UserProfile.tags.list.contains("python")
 )
 
-# Get element by index (0-based)
-first_tags = df.with_columns(
-    UserProfile.tags.list.get(0).alias(UserProfile.tags)
-)
+# Count elements in each list — use a separate output column
+class ProfileWithCounts(UserProfile):
+    tag_count: Column[UInt32]
 
-# Aggregate list elements (numeric lists)
-score_totals = df.with_columns(
-    UserProfile.scores.list.sum().alias(UserProfile.scores)
-)
+tag_counts = df.with_columns(
+    UserProfile.tags.list.len().alias(ProfileWithCounts.tag_count)
+).cast_schema(ProfileWithCounts)
+
+# Get element by index, aggregate list elements
+UserProfile.tags.list.get(0)      # first tag
+UserProfile.scores.list.sum()     # sum of scores
+UserProfile.scores.list.mean()    # mean of scores
 ```
 
 ## Available list methods

--- a/uv.lock
+++ b/uv.lock
@@ -181,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "colnade"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 
 [package.dev-dependencies]
@@ -218,7 +218,7 @@ dev = [
 
 [[package]]
 name = "colnade-dask"
-version = "0.3.6"
+version = "0.3.7"
 source = { editable = "colnade-dask" }
 dependencies = [
     { name = "colnade" },
@@ -237,7 +237,7 @@ requires-dist = [
 
 [[package]]
 name = "colnade-pandas"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "colnade-pandas" }
 dependencies = [
     { name = "colnade" },
@@ -255,7 +255,7 @@ requires-dist = [
 
 [[package]]
 name = "colnade-polars"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "colnade-polars" }
 dependencies = [
     { name = "colnade" },


### PR DESCRIPTION
## Summary

- Fix homepage's central claim: Polars raises `ColumnNotFoundError` on typos, not "silently produces zero rows" — reframed as "crashes at runtime" vs "caught in your editor"
- Fix list aliasing examples across README, tutorial, and `examples/nested_types.py` — use separate output columns with child schemas instead of aliasing computed results back to the source column (which overwrites the column with an incompatible type)
- Explain the `select` → `cast_schema` transition in Quick Start (step 3→4 was jarring — `select` changes columns so it returns `DataFrame[Any]`)
- Document list operations type safety limitation in `docs/user-guide/type-checking.md` (`.list` returns `ListAccessor[Any]` due to missing property self-narrowing in type checkers)
- Replace "runtime trust boundary" jargon in `docs/comparison.md` footnote with plain description
- Remove vague "schema violations" from README opening line — replaced with specific "column misspellings and type mismatches"
- Sync `uv.lock` with v0.7.0 version bump

Closes #155

## Test plan

- [x] All 7 pre-commit checks pass
- [x] `examples/nested_types.py` runs correctly with new child schema pattern
- [x] `mkdocs build --strict` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)