### PR TITLE
Adopt `import colnade as cn` convention in docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -38,11 +38,11 @@ uv sync
 ## Verify installation
 
 ```python
-from colnade import Column, Schema, UInt64, Utf8
+import colnade as cn
 
-class TestSchema(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
+class TestSchema(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
 
 print("Colnade installed successfully!")
 ```

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -7,13 +7,13 @@ This guide walks through Colnade's core workflow in 5 minutes.
 Schemas declare the shape of your data with typed columns:
 
 ```python
-from colnade import Column, Schema, UInt64, Float64, Utf8
+import colnade as cn
 
-class Users(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    age: Column[UInt64]
-    score: Column[Float64]
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    age: cn.Column[cn.UInt64]
+    score: cn.Column[cn.Float64]
 ```
 
 Each `Column[DType]` annotation creates a typed descriptor. `Users.age` is a `Column[UInt64]` that the type checker can verify.
@@ -49,9 +49,9 @@ All these operations return `DataFrame[Users]` — the schema type is preserved.
 Operations like `filter` and `sort` keep all columns, so they preserve `DataFrame[Users]`. But `select` changes which columns exist, so it returns `DataFrame[Any]`. Use `cast_schema()` to bind the result to a new schema:
 
 ```python
-class UserSummary(Schema):
-    name: Column[Utf8]
-    score: Column[Float64]
+class UserSummary(cn.Schema):
+    name: cn.Column[cn.Utf8]
+    score: cn.Column[cn.Float64]
 
 summary = df.select(Users.name, Users.score).cast_schema(UserSummary)
 # summary is DataFrame[UserSummary]

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,14 +96,14 @@ Works with `ty`, `mypy`, and `pyright` out of the box. Standard Python classes, 
 ## Quick Example
 
 ```python
-from colnade import Column, Schema, UInt64, Float64, Utf8
+import colnade as cn
 from colnade_polars import read_parquet
 
-class Users(Schema):
-    id:    Column[UInt64]
-    name:  Column[Utf8]
-    age:   Column[UInt64]
-    score: Column[Float64]
+class Users(cn.Schema):
+    id:    cn.Column[cn.UInt64]
+    name:  cn.Column[cn.Utf8]
+    age:   cn.Column[cn.UInt64]
+    score: cn.Column[cn.Float64]
 
 df = read_parquet("users.parquet", Users)  # DataFrame[Users]
 

--- a/docs/tutorials/basic-usage.md
+++ b/docs/tutorials/basic-usage.md
@@ -8,17 +8,17 @@ This tutorial demonstrates the core Colnade workflow: define a schema, read data
 ## Define schemas
 
 ```python
-from colnade import Column, Schema, UInt64, Float64, Utf8
+import colnade as cn
 
-class Users(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    age: Column[UInt64]
-    score: Column[Float64]
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    age: cn.Column[cn.UInt64]
+    score: cn.Column[cn.Float64]
 
-class UserSummary(Schema):
-    name: Column[Utf8]
-    score: Column[Float64]
+class UserSummary(cn.Schema):
+    name: cn.Column[cn.Utf8]
+    score: cn.Column[cn.Float64]
 ```
 
 ## Read typed data

--- a/docs/tutorials/full-pipeline.md
+++ b/docs/tutorials/full-pipeline.md
@@ -8,30 +8,30 @@ This tutorial demonstrates a complete ETL pipeline: read data, clean nulls, filt
 ## Define schemas
 
 ```python
-from colnade import Column, Schema, UInt64, Float64, Utf8, mapped_from
+import colnade as cn
 
-class Users(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    age: Column[UInt64]
-    score: Column[Float64]
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    age: cn.Column[cn.UInt64]
+    score: cn.Column[cn.Float64]
 
-class Orders(Schema):
-    id: Column[UInt64]
-    user_id: Column[UInt64]
-    amount: Column[Float64]
+class Orders(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    user_id: cn.Column[cn.UInt64]
+    amount: cn.Column[cn.Float64]
 
-class UserOrders(Schema):
+class UserOrders(cn.Schema):
     """Intermediate schema after joining users with orders."""
-    user_name: Column[Utf8] = mapped_from(Users.name)
-    user_id: Column[UInt64] = mapped_from(Users.id)
-    amount: Column[Float64] = mapped_from(Orders.amount)
+    user_name: cn.Column[cn.Utf8] = cn.mapped_from(Users.name)
+    user_id: cn.Column[cn.UInt64] = cn.mapped_from(Users.id)
+    amount: cn.Column[cn.Float64] = cn.mapped_from(Orders.amount)
 
-class UserRevenue(Schema):
+class UserRevenue(cn.Schema):
     """Output schema: per-user revenue summary."""
-    user_name: Column[Utf8]
-    user_id: Column[UInt64]
-    total_amount: Column[Float64]
+    user_name: cn.Column[cn.Utf8]
+    user_id: cn.Column[cn.UInt64]
+    total_amount: cn.Column[cn.Float64]
 ```
 
 ## Step 1: Read typed data

--- a/docs/tutorials/generic-functions.md
+++ b/docs/tutorials/generic-functions.md
@@ -10,7 +10,7 @@ This tutorial demonstrates how to write schema-polymorphic utility functions tha
 Import the schema-bound TypeVar `S`:
 
 ```python
-from colnade import DataFrame
+import colnade as cn
 from colnade.schema import S
 ```
 
@@ -19,15 +19,15 @@ from colnade.schema import S
 ## Writing generic functions
 
 ```python
-def first_n(df: DataFrame[S], n: int) -> DataFrame[S]:
+def first_n(df: cn.DataFrame[S], n: int) -> cn.DataFrame[S]:
     """Return the first n rows. Works with any schema."""
     return df.head(n)
 
-def drop_null_rows(df: DataFrame[S]) -> DataFrame[S]:
+def drop_null_rows(df: cn.DataFrame[S]) -> cn.DataFrame[S]:
     """Drop all rows with any null values."""
     return df.drop_nulls()
 
-def count_rows(df: DataFrame[S]) -> int:
+def count_rows(df: cn.DataFrame[S]) -> int:
     """Count rows in any typed DataFrame."""
     return len(df)
 ```
@@ -37,8 +37,8 @@ def count_rows(df: DataFrame[S]) -> int:
 The type checker knows the concrete schema at each call site:
 
 ```python
-users: DataFrame[Users] = read_parquet("users.parquet", Users)
-products: DataFrame[Products] = read_parquet("products.parquet", Products)
+users: cn.DataFrame[Users] = read_parquet("users.parquet", Users)
+products: cn.DataFrame[Products] = read_parquet("products.parquet", Products)
 
 # first_n preserves the input schema
 top_users = first_n(users, 10)          # DataFrame[Users]
@@ -54,7 +54,7 @@ clean_products = drop_null_rows(products)  # DataFrame[Products]
 Generic functions compose naturally in pipelines:
 
 ```python
-def standard_cleanup(df: DataFrame[S]) -> DataFrame[S]:
+def standard_cleanup(df: cn.DataFrame[S]) -> cn.DataFrame[S]:
     """Standard cleanup: drop nulls, deduplicate, sort by first column."""
     return df.drop_nulls()
 

--- a/docs/tutorials/joins.md
+++ b/docs/tutorials/joins.md
@@ -8,22 +8,22 @@ This tutorial demonstrates joining DataFrames from different schemas and flatten
 ## Define schemas
 
 ```python
-from colnade import Column, Schema, UInt64, Float64, Utf8, mapped_from
+import colnade as cn
 
-class Users(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    age: Column[UInt64]
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    age: cn.Column[cn.UInt64]
 
-class Orders(Schema):
-    id: Column[UInt64]
-    user_id: Column[UInt64]
-    amount: Column[Float64]
+class Orders(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    user_id: cn.Column[cn.UInt64]
+    amount: cn.Column[cn.Float64]
 
-class UserOrders(Schema):
-    user_name: Column[Utf8] = mapped_from(Users.name)
-    user_id: Column[UInt64] = mapped_from(Users.id)
-    amount: Column[Float64]
+class UserOrders(cn.Schema):
+    user_name: cn.Column[cn.Utf8] = cn.mapped_from(Users.name)
+    user_id: cn.Column[cn.UInt64] = cn.mapped_from(Users.id)
+    amount: cn.Column[cn.Float64]
 ```
 
 The `UserOrders` output schema uses `mapped_from` to disambiguate — both `Users` and `Orders` have an `id` column.

--- a/docs/tutorials/nested-types.md
+++ b/docs/tutorials/nested-types.md
@@ -8,18 +8,18 @@ This tutorial demonstrates working with struct and list columns.
 ## Define schemas with nested types
 
 ```python
-from colnade import Column, Schema, Struct, List, UInt32, UInt64, Float64, Utf8
+import colnade as cn
 
-class Address(Schema):
-    city: Column[Utf8]
-    zip_code: Column[Utf8]
+class Address(cn.Schema):
+    city: cn.Column[cn.Utf8]
+    zip_code: cn.Column[cn.Utf8]
 
-class UserProfile(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    address: Column[Struct[Address]]
-    tags: Column[List[Utf8]]
-    scores: Column[List[Float64]]
+class UserProfile(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    address: cn.Column[cn.Struct[Address]]
+    tags: cn.Column[cn.List[cn.Utf8]]
+    scores: cn.Column[cn.List[cn.Float64]]
 ```
 
 ## Struct field access
@@ -50,9 +50,9 @@ python_users = df.filter(
 
 # Compute list aggregations into new columns
 class ProfileWithStats(UserProfile):
-    tag_count: Column[UInt32]
-    first_tag: Column[Utf8]
-    total_score: Column[Float64]
+    tag_count: cn.Column[cn.UInt32]
+    first_tag: cn.Column[cn.Utf8]
+    total_score: cn.Column[cn.Float64]
 
 enriched = df.with_columns(
     UserProfile.tags.list.len().alias(ProfileWithStats.tag_count),

--- a/docs/tutorials/null-handling.md
+++ b/docs/tutorials/null-handling.md
@@ -8,14 +8,14 @@ This tutorial demonstrates how to work with nullable data in Colnade.
 ## Setup
 
 ```python
-from colnade import Column, Float64, Schema, UInt64, Utf8
+import colnade as cn
 from colnade_polars import from_dict
 
-class Users(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    age: Column[UInt64 | None]
-    score: Column[Float64 | None]
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    age: cn.Column[cn.UInt64 | None]
+    score: cn.Column[cn.Float64 | None]
 
 df = from_dict(Users, {
     "id": [1, 2, 3, 4, 5],

--- a/docs/user-guide/core-concepts.md
+++ b/docs/user-guide/core-concepts.md
@@ -22,10 +22,12 @@ graph TD
 Schemas define the structure of your data. They are Python classes that extend `Schema`:
 
 ```python
-class Users(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    age: Column[UInt64]
+import colnade as cn
+
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    age: cn.Column[cn.UInt64]
 ```
 
 The metaclass (`SchemaMeta`) converts each `Column[DType]` annotation into a descriptor object. `Users.age` is a `Column[UInt64]` instance — not a string, not an integer. The type checker can verify attribute access.
@@ -95,20 +97,18 @@ When validation is enabled, data boundaries (`read_parquet`, `from_batches`, `ca
 - **Null violations** — non-nullable columns containing null values
 - **Expression column membership** — operations like `filter`, `sort`, `select` verify that all column references in expressions belong to the frame's schema (e.g., using `Orders.amount` on a `DataFrame[Users]` raises `SchemaError`)
 
-Enable with `colnade.set_validation(ValidationLevel.STRUCTURAL)` or `COLNADE_VALIDATE=structural`. See [DataFrames: Validation](dataframes.md#validation) for details.
+Enable with `cn.set_validation(cn.ValidationLevel.STRUCTURAL)` or `COLNADE_VALIDATE=structural`. See [DataFrames: Validation](dataframes.md#validation) for details.
 
 ### 3. On your data values
 
 Value-level constraints validate domain invariants using `Field()` metadata:
 
 ```python
-from colnade.constraints import Field, schema_check
-
-class Users(Schema):
-    id: Column[UInt64] = Field(unique=True)
-    age: Column[UInt64] = Field(ge=0, le=150)
-    email: Column[Utf8] = Field(pattern=r"^[^@]+@[^@]+\.[^@]+$")
-    status: Column[Utf8] = Field(isin=["active", "inactive"])
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64] = cn.Field(unique=True)
+    age: cn.Column[cn.UInt64] = cn.Field(ge=0, le=150)
+    email: cn.Column[cn.Utf8] = cn.Field(pattern=r"^[^@]+@[^@]+\.[^@]+$")
+    status: cn.Column[cn.Utf8] = cn.Field(isin=["active", "inactive"])
 ```
 
 Checked by `df.validate()` (always) and by auto-validation at the `FULL` level. See [DataFrames: Value-level constraints](dataframes.md#level-3-on-your-data-values-value-level-constraints) for the full constraint reference.

--- a/docs/user-guide/dask-backend.md
+++ b/docs/user-guide/dask-backend.md
@@ -44,11 +44,10 @@ Structural validation checks column names, dtypes, and nullability. With Dask:
 - **Null checks** require computation — Dask must scan data to determine if non-nullable columns contain nulls.
 
 ```python
-import colnade
-from colnade import ValidationLevel
+import colnade as cn
 from colnade_dask import scan_parquet
 
-colnade.set_validation(ValidationLevel.STRUCTURAL)
+cn.set_validation(cn.ValidationLevel.STRUCTURAL)
 
 # This triggers partial computation for null checks:
 lf = scan_parquet("users.parquet", Users)
@@ -59,7 +58,7 @@ lf = scan_parquet("users.parquet", Users)
 Full validation adds value-level constraint checks (`Field()` constraints, `@schema_check`). With Dask, this **materializes the entire DataFrame** because constraints like `ge=0`, `pattern=...`, and `unique=True` must inspect actual data values.
 
 ```python
-colnade.set_validation(ValidationLevel.FULL)
+cn.set_validation(cn.ValidationLevel.FULL)
 
 # This triggers full computation:
 lf = scan_parquet("users.parquet", Users)
@@ -104,9 +103,9 @@ However, this means the entire dataset must fit in memory on a single worker dur
 `cast_schema()` applies column renames and selection lazily — no computation is triggered. The column mapping is resolved and applied as Dask task graph operations.
 
 ```python
-class UserSummary(Schema):
-    user_name: Column[Utf8] = mapped_from(Users.name)
-    user_id: Column[UInt64] = mapped_from(Users.id)
+class UserSummary(cn.Schema):
+    user_name: cn.Column[cn.Utf8] = cn.mapped_from(Users.name)
+    user_id: cn.Column[cn.UInt64] = cn.mapped_from(Users.id)
 
 # No computation — just builds rename tasks:
 summary = lf.cast_schema(UserSummary)

--- a/docs/user-guide/dataframes.md
+++ b/docs/user-guide/dataframes.md
@@ -87,15 +87,13 @@ df.with_columns(                             # add/overwrite columns
 Stack DataFrames vertically with `concat()`:
 
 ```python
-from colnade import concat
-
-combined = concat(df_jan, df_feb, df_mar)  # DataFrame[Sales]
+combined = cn.concat(df_jan, df_feb, df_mar)  # DataFrame[Sales]
 ```
 
 All inputs must share the **same schema class** — this is an identity check (`is`), not structural equality. Two different schema classes with identical fields will be rejected. Works with both `DataFrame` and `LazyFrame` (but you cannot mix them in one call):
 
 ```python
-combined = concat(lazy_jan, lazy_feb)  # LazyFrame[Sales]
+combined = cn.concat(lazy_jan, lazy_feb)  # LazyFrame[Sales]
 ```
 
 Rows appear in input order: all rows from the first frame, then all rows from the second, and so on. At least 2 frames are required.
@@ -127,9 +125,9 @@ After a schema-transforming operation, use `cast_schema()` to bind to a named ou
 `cast_schema` binds data to a new schema by resolving column mappings:
 
 ```python
-class UserSummary(Schema):
-    name: Column[Utf8]
-    score: Column[Float64]
+class UserSummary(cn.Schema):
+    name: cn.Column[cn.Utf8]
+    score: cn.Column[cn.Float64]
 
 summary = df.select(Users.name, Users.score).cast_schema(UserSummary)
 # summary is DataFrame[UserSummary]
@@ -155,10 +153,10 @@ The `extra` parameter controls extra columns in the source:
 - **Use `mapped_from`** on output schema fields to create static links between input and output columns. The more fields that declare their provenance, the narrower the trust gap:
 
     ```python
-    class UserRevenue(Schema):
-        user_name: Column[Utf8] = mapped_from(Users.name)
-        user_id: Column[UInt64] = mapped_from(Users.id)
-        total_amount: Column[Float64]  # only this field is "trust me"
+    class UserRevenue(cn.Schema):
+        user_name: cn.Column[cn.Utf8] = cn.mapped_from(Users.name)
+        user_id: cn.Column[cn.UInt64] = cn.mapped_from(Users.id)
+        total_amount: cn.Column[cn.Float64]  # only this field is "trust me"
     ```
 
 - **Use `extra="forbid"`** to catch unexpected columns that might indicate a wrong select.
@@ -260,13 +258,12 @@ Checks column existence, data types, and nullability constraints.
 Enable auto-validation at data boundaries:
 
 ```python
-import colnade
-from colnade import ValidationLevel
+import colnade as cn
 
-colnade.set_validation(ValidationLevel.STRUCTURAL)  # or FULL
+cn.set_validation(cn.ValidationLevel.STRUCTURAL)  # or FULL
 # Strings and booleans still work for convenience:
-colnade.set_validation("structural")
-colnade.set_validation(True)  # → STRUCTURAL
+cn.set_validation("structural")
+cn.set_validation(True)  # → STRUCTURAL
 ```
 
 Or via environment variable:
@@ -307,16 +304,15 @@ When validation is enabled, data boundaries and `df.validate()` check:
 Value-level constraints validate domain invariants using `Field()` metadata:
 
 ```python
-from colnade import Column, Schema, UInt64, Utf8, Float64
-from colnade.constraints import Field, schema_check
+import colnade as cn
 
-class Users(Schema):
-    id: Column[UInt64] = Field(unique=True)
-    age: Column[UInt64] = Field(ge=0, le=150)
-    name: Column[Utf8] = Field(min_length=1)
-    email: Column[Utf8] = Field(pattern=r"^[^@]+@[^@]+\.[^@]+$")
-    score: Column[Float64] = Field(ge=0.0, le=100.0)
-    status: Column[Utf8] = Field(isin=["active", "inactive"])
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64] = cn.Field(unique=True)
+    age: cn.Column[cn.UInt64] = cn.Field(ge=0, le=150)
+    name: cn.Column[cn.Utf8] = cn.Field(min_length=1)
+    email: cn.Column[cn.Utf8] = cn.Field(pattern=r"^[^@]+@[^@]+\.[^@]+$")
+    score: cn.Column[cn.Float64] = cn.Field(ge=0.0, le=100.0)
+    status: cn.Column[cn.Utf8] = cn.Field(isin=["active", "inactive"])
 ```
 
 Available constraints:
@@ -338,11 +334,11 @@ Available constraints:
 Cross-column constraints use `@schema_check`:
 
 ```python
-class Events(Schema):
-    start: Column[UInt64]
-    end: Column[UInt64]
+class Events(cn.Schema):
+    start: cn.Column[cn.UInt64]
+    end: cn.Column[cn.UInt64]
 
-    @schema_check
+    @cn.schema_check
     def start_before_end(cls):
         return Events.start <= Events.end
 ```
@@ -361,7 +357,7 @@ Use `with_columns` to add a computed column, then `cast_schema` to transition to
 
 ```python
 class EnrichedUsers(Users):
-    risk_score: Column[Float64]
+    risk_score: cn.Column[cn.Float64]
 
 result = df.with_columns(
     (Users.age * 0.1 + Users.score * 0.9).alias(EnrichedUsers.risk_score)

--- a/docs/user-guide/expressions.md
+++ b/docs/user-guide/expressions.md
@@ -62,10 +62,10 @@ Users.name.n_unique()   # unique count (returns UInt32)
 Use `.alias()` to bind aggregation results to output columns:
 
 ```python
-class Stats(Schema):
-    name: Column[Utf8]
-    avg_score: Column[Float64]
-    user_count: Column[UInt32]
+class Stats(cn.Schema):
+    name: cn.Column[cn.Utf8]
+    avg_score: cn.Column[cn.Float64]
+    user_count: cn.Column[cn.UInt32]
 
 df.group_by(Users.name).agg(
     Users.score.mean().alias(Stats.avg_score),
@@ -152,25 +152,23 @@ Users.id.cast(Float64)                # cast UInt64 → Float64
 Build if/else logic with `when/then/otherwise`:
 
 ```python
-from colnade import when, lit
-
 # Simple condition
-when(Users.age > 65).then("senior").otherwise("standard")
+cn.when(Users.age > 65).then("senior").otherwise("standard")
 
 # Multi-branch (chained when)
-when(Users.score > 90).then("A").when(Users.score > 80).then("B").otherwise("C")
+cn.when(Users.score > 90).then("A").when(Users.score > 80).then("B").otherwise("C")
 
 # Use in with_columns
 df.with_columns(
-    when(Users.age > 65).then(lit("senior")).otherwise(lit("standard")).alias(Users.tier)
+    cn.when(Users.age > 65).then(cn.lit("senior")).otherwise(cn.lit("standard")).alias(Users.tier)
 )
 ```
 
 Conditions can use any boolean expression, including combined conditions:
 
 ```python
-when((Users.age > 25) & (Users.age < 65)).then("working_age").otherwise("other")
-when(Users.name == "Alice").then("found").otherwise("not_found")
+cn.when((Users.age > 25) & (Users.age < 65)).then("working_age").otherwise("other")
+cn.when(Users.name == "Alice").then("found").otherwise("not_found")
 ```
 
 Branch values can be column references or expressions, not just literals:

--- a/docs/user-guide/joins.md
+++ b/docs/user-guide/joins.md
@@ -69,10 +69,10 @@ result = (
 Use `cast_schema` to flatten a `JoinedDataFrame` into a single-schema `DataFrame`:
 
 ```python
-class UserOrders(Schema):
-    user_name: Column[Utf8] = mapped_from(Users.name)
-    user_id: Column[UInt64] = mapped_from(Users.id)
-    amount: Column[Float64]
+class UserOrders(cn.Schema):
+    user_name: cn.Column[cn.Utf8] = cn.mapped_from(Users.name)
+    user_id: cn.Column[cn.UInt64] = cn.mapped_from(Users.id)
+    amount: cn.Column[cn.Float64]
 
 result = joined.cast_schema(UserOrders)
 # result is DataFrame[UserOrders]
@@ -83,10 +83,10 @@ result = joined.cast_schema(UserOrders)
 When both schemas have a column with the same name (e.g., both `Users` and `Orders` have `id`), use `mapped_from` to specify which source you want:
 
 ```python
-class JoinOutput(Schema):
-    user_id: Column[UInt64] = mapped_from(Users.id)       # from Users
-    order_id: Column[UInt64] = mapped_from(Orders.id)     # from Orders
-    amount: Column[Float64]                                # unambiguous name match
+class JoinOutput(cn.Schema):
+    user_id: cn.Column[cn.UInt64] = cn.mapped_from(Users.id)       # from Users
+    order_id: cn.Column[cn.UInt64] = cn.mapped_from(Orders.id)     # from Orders
+    amount: cn.Column[cn.Float64]                                   # unambiguous name match
 ```
 
 Without `mapped_from`, ambiguous column names (present in both schemas) are skipped during name matching and will produce a `SchemaError` for missing columns.

--- a/docs/user-guide/nested-types.md
+++ b/docs/user-guide/nested-types.md
@@ -7,15 +7,15 @@ Colnade supports struct and list columns with typed access to nested data.
 Define a struct column by parameterizing `Struct` with a schema:
 
 ```python
-from colnade import Column, Schema, Struct, Utf8
+import colnade as cn
 
-class Address(Schema):
-    city: Column[Utf8]
-    zip_code: Column[Utf8]
+class Address(cn.Schema):
+    city: cn.Column[cn.Utf8]
+    zip_code: cn.Column[cn.Utf8]
 
-class Users(Schema):
-    name: Column[Utf8]
-    address: Column[Struct[Address]]
+class Users(cn.Schema):
+    name: cn.Column[cn.Utf8]
+    address: cn.Column[cn.Struct[Address]]
 ```
 
 ### Accessing struct fields
@@ -37,11 +37,9 @@ The `.field()` method returns a `StructFieldAccess` expression node that support
 Define a list column by parameterizing `List` with an element type:
 
 ```python
-from colnade import Column, Schema, List, Float64, Utf8
-
-class Users(Schema):
-    tags: Column[List[Utf8]]
-    scores: Column[List[Float64]]
+class Users(cn.Schema):
+    tags: cn.Column[cn.List[cn.Utf8]]
+    scores: cn.Column[cn.List[cn.Float64]]
 ```
 
 ### List operations
@@ -83,7 +81,7 @@ df.with_columns(Users.scores.list.sum().alias(Users.scores))
 Mark nested columns as nullable with `| None`:
 
 ```python
-class Users(Schema):
-    address: Column[Struct[Address] | None]   # nullable struct
-    tags: Column[List[Utf8] | None]           # nullable list
+class Users(cn.Schema):
+    address: cn.Column[cn.Struct[Address] | None]   # nullable struct
+    tags: cn.Column[cn.List[cn.Utf8] | None]           # nullable list
 ```

--- a/docs/user-guide/type-checking.md
+++ b/docs/user-guide/type-checking.md
@@ -59,11 +59,11 @@ This applies to numeric aggregations (`sum`, `mean`, `std`, `var`), NaN methods 
 ### Nullability mismatch in mapped_from
 
 ```python
-class Users(Schema):
-    age: Column[UInt8 | None]  # nullable
+class Users(cn.Schema):
+    age: cn.Column[cn.UInt8 | None]  # nullable
 
-class Bad(Schema):
-    age: Column[UInt8] = mapped_from(Users.age)  # non-nullable target
+class Bad(cn.Schema):
+    age: cn.Column[cn.UInt8] = cn.mapped_from(Users.age)  # non-nullable target
 ```
 
 ```
@@ -94,10 +94,9 @@ This is a fundamental limitation — Python lacks type-level functions to map `C
 **Runtime alternative:** Enable validation and these mismatches are caught at expression construction time:
 
 ```python
-import colnade
-from colnade import ValidationLevel
+import colnade as cn
 
-colnade.set_validation(ValidationLevel.STRUCTURAL)
+cn.set_validation(cn.ValidationLevel.STRUCTURAL)
 # or: COLNADE_VALIDATE=structural
 
 Users.age.fill_null(1.0)
@@ -121,10 +120,10 @@ This is a fundamental limitation of the current type system. Column descriptors 
 **Runtime alternative:** When validation is enabled (`STRUCTURAL` or `FULL`), DataFrame and LazyFrame operations validate that all column references in an expression belong to the frame's schema. The example above raises `SchemaError` at runtime:
 
 ```python
-colnade.set_validation(ValidationLevel.STRUCTURAL)
+cn.set_validation(cn.ValidationLevel.STRUCTURAL)
 
 df.filter(Orders.amount > 100)
-# SchemaError: Missing columns: amount
+# cn.SchemaError: Missing columns: amount
 ```
 
 This guard covers `filter`, `sort`, `with_columns`, `select`, `unique`, `drop_nulls`, `group_by`, and `agg`. On `JoinedDataFrame`/`JoinedLazyFrame`, columns from either schema are accepted.


### PR DESCRIPTION
## Summary
- Replace `from colnade import X, Y, Z` with `import colnade as cn` + `cn.X` across all 18 documentation files and README
- Matches the ecosystem convention (`import polars as pl`, `import pandas as pd`)
- `from colnade.schema import S` kept as-is (not in `__all__`)
- Backend imports unchanged (`from colnade_polars import read_parquet`)

Closes #166

## Test plan
- [x] All 7 pre-commit checks pass (ruff, format, pytest, ty, api docs, changelog, mkdocs strict)
- [x] Verified no remaining bare `from colnade import` in code blocks
- [x] Verified no remaining bare `Column[` or `(Schema):` without `cn.` prefix in code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)