### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-02-28
+
 ### Added
 
 - **`when/then/otherwise` conditional expressions** — build multi-branch if/else logic in the expression DSL: `when(Users.age > 65).then("senior").otherwise("standard")`. Supports chained conditions and works with all three backends (#159)
 - **`concat()` for vertical concatenation** — stack DataFrames or LazyFrames vertically with type-safe schema preservation: `concat(df1, df2, df3)`. Validates all inputs share the same schema (#160)
 - **`.item()` for scalar extraction** — extract a Python scalar from a 1-row DataFrame or LazyFrame: `df.agg(...).item()` or `df.head(1).item(Users.name)`. Return type is inferred from the column dtype via overloads (#161)
+
+### Fixed
+
+- **`.item()` on Polars LazyFrame** no longer crashes — was missing `.collect()` before accessing `.shape` (#165)
+- **`.item()` on Pandas/Dask** now returns `None` instead of leaking `pd.NA` for null cells (#165)
+
+### Changed
+
+- Documentation adopts `import colnade as cn` convention across all examples (#166)
+
+### Infrastructure
+
+- README images use absolute URLs for PyPI rendering (#164)
+- Performance docs rewritten with accurate benchmarks (#151)
+- Three rounds of documentation audit fixes (#153, #155, #157)
+- Removed spec.md — superseded by docs/ and CLAUDE.md (#152)
 
 ## [0.7.0] - 2026-02-24
 
@@ -117,7 +135,8 @@ First public release.
 - **Untyped escape hatch** — `df.untyped()` drops to string-based columns, `untyped.to_typed(Schema)` re-binds
 - **Documentation site** — tutorials, user guide, API reference, comparison page at colnade.com
 
-[Unreleased]: https://github.com/jwde/colnade/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/jwde/colnade/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/jwde/colnade/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/jwde/colnade/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/jwde/colnade/compare/v0.5.5...v0.6.0
 [0.5.5]: https://github.com/jwde/colnade/compare/v0.5.4...v0.5.5

--- a/colnade-dask/pyproject.toml
+++ b/colnade-dask/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "colnade-dask"
-version = "0.3.7"
+version = "0.4.0"
 description = "Dask backend adapter for Colnade"
 requires-python = ">=3.10"
 license = "MIT"

--- a/colnade-pandas/pyproject.toml
+++ b/colnade-pandas/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "colnade-pandas"
-version = "0.3.5"
+version = "0.4.0"
 description = "Pandas backend adapter for Colnade"
 requires-python = ">=3.10"
 license = "MIT"

--- a/colnade-polars/pyproject.toml
+++ b/colnade-polars/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "colnade-polars"
-version = "0.5.5"
+version = "0.6.0"
 description = "Polars backend adapter for Colnade"
 requires-python = ">=3.10"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "colnade"
-version = "0.7.0"
+version = "0.8.0"
 description = "A statically type-safe DataFrame abstraction layer"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump colnade 0.7.0 → 0.8.0, colnade-polars 0.5.5 → 0.6.0, colnade-pandas 0.3.5 → 0.4.0, colnade-dask 0.3.7 → 0.4.0
- Convert changelog `[Unreleased]` → `[0.8.0] - 2026-02-28`

## What's in v0.8.0

### Added
- `when/then/otherwise` conditional expressions (#159)
- `concat()` for vertical concatenation (#160)
- `.item()` for scalar extraction (#161)

### Fixed
- `.item()` on Polars LazyFrame crash (#165)
- `.item()` pd.NA leak on Pandas/Dask (#165)

### Changed
- Documentation adopts `import colnade as cn` convention (#166)

### Infrastructure
- README images for PyPI (#164), performance docs (#151), docs audit (#153, #155, #157), spec removal (#152)

## After merge
```bash
git tag -a v0.8.0 -m "Release v0.8.0"
git push origin v0.8.0
```
Then create a GitHub release from the tag to trigger PyPI publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)