### PR TITLE
Fix examples import convention and docs correctness

### DIFF
--- a/docs/tutorials/full-pipeline.md
+++ b/docs/tutorials/full-pipeline.md
@@ -14,7 +14,7 @@ class Users(cn.Schema):
     id: cn.Column[cn.UInt64]
     name: cn.Column[cn.Utf8]
     age: cn.Column[cn.UInt64]
-    score: cn.Column[cn.Float64]
+    score: cn.Column[cn.Float64 | None]
 
 class Orders(cn.Schema):
     id: cn.Column[cn.UInt64]

--- a/docs/tutorials/nested-types.md
+++ b/docs/tutorials/nested-types.md
@@ -49,16 +49,16 @@ python_users = df.filter(
 )
 
 # Compute list aggregations into new columns
-class ProfileWithStats(UserProfile):
+class ProfileWithCounts(UserProfile):
     tag_count: cn.Column[cn.UInt32]
     first_tag: cn.Column[cn.Utf8]
     total_score: cn.Column[cn.Float64]
 
 enriched = df.with_columns(
-    UserProfile.tags.list.len().alias(ProfileWithStats.tag_count),
-    UserProfile.tags.list.get(0).alias(ProfileWithStats.first_tag),
-    UserProfile.scores.list.sum().alias(ProfileWithStats.total_score),
-).cast_schema(ProfileWithStats)
+    UserProfile.tags.list.len().alias(ProfileWithCounts.tag_count),
+    UserProfile.tags.list.get(0).alias(ProfileWithCounts.first_tag),
+    UserProfile.scores.list.sum().alias(ProfileWithCounts.total_score),
+).cast_schema(ProfileWithCounts)
 ```
 
 ## Available list methods

--- a/docs/user-guide/dataframes.md
+++ b/docs/user-guide/dataframes.md
@@ -72,8 +72,8 @@ df.filter(Users.age > 25)                    # filter rows
 df.sort(Users.score.desc())                  # sort rows
 df.sort(Users.name, Users.age)               # sort by multiple columns
 df.limit(100)                                # first n rows
-df.head(10)                                  # first n rows (eager only)
-df.tail(10)                                  # last n rows (eager only)
+df.head(10)                                  # first n rows
+df.tail(10)                                  # last n rows
 df.sample(50)                                # random sample (eager only)
 df.unique(Users.name)                        # deduplicate by columns
 df.drop_nulls(Users.age, Users.score)        # drop null rows

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import tempfile
 
-from colnade import Column, Float64, Schema, UInt64, Utf8
+import colnade as cn
 from colnade_polars import from_rows, read_parquet, write_parquet
 
 # ---------------------------------------------------------------------------
@@ -15,16 +15,16 @@ from colnade_polars import from_rows, read_parquet, write_parquet
 # ---------------------------------------------------------------------------
 
 
-class Users(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    age: Column[UInt64]
-    score: Column[Float64]
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    age: cn.Column[cn.UInt64]
+    score: cn.Column[cn.Float64]
 
 
-class UserSummary(Schema):
-    name: Column[Utf8]
-    score: Column[Float64]
+class UserSummary(cn.Schema):
+    name: cn.Column[cn.Utf8]
+    score: cn.Column[cn.Float64]
 
 
 # ---------------------------------------------------------------------------

--- a/examples/full_pipeline.py
+++ b/examples/full_pipeline.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from colnade import Column, Float64, Schema, UInt64, Utf8, mapped_from
+import colnade as cn
 from colnade_polars import from_dict, read_parquet, write_parquet
 
 # ---------------------------------------------------------------------------
@@ -17,33 +17,33 @@ from colnade_polars import from_dict, read_parquet, write_parquet
 # ---------------------------------------------------------------------------
 
 
-class Users(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    age: Column[UInt64]
-    score: Column[Float64]
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    age: cn.Column[cn.UInt64]
+    score: cn.Column[cn.Float64 | None]
 
 
-class Orders(Schema):
-    id: Column[UInt64]
-    user_id: Column[UInt64]
-    amount: Column[Float64]
+class Orders(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    user_id: cn.Column[cn.UInt64]
+    amount: cn.Column[cn.Float64]
 
 
-class UserOrders(Schema):
+class UserOrders(cn.Schema):
     """Intermediate schema after joining users with orders."""
 
-    user_name: Column[Utf8] = mapped_from(Users.name)
-    user_id: Column[UInt64] = mapped_from(Users.id)
-    amount: Column[Float64] = mapped_from(Orders.amount)
+    user_name: cn.Column[cn.Utf8] = cn.mapped_from(Users.name)
+    user_id: cn.Column[cn.UInt64] = cn.mapped_from(Users.id)
+    amount: cn.Column[cn.Float64] = cn.mapped_from(Orders.amount)
 
 
-class UserRevenue(Schema):
+class UserRevenue(cn.Schema):
     """Output schema: per-user revenue summary."""
 
-    user_name: Column[Utf8]
-    user_id: Column[UInt64]
-    total_amount: Column[Float64]
+    user_name: cn.Column[cn.Utf8]
+    user_id: cn.Column[cn.UInt64]
+    total_amount: cn.Column[cn.Float64]
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +135,7 @@ revenue = (
 )
 
 # Step 6: Sort by revenue descending
-result = revenue.sort(UserRevenue.total_amount, descending=True)
+result = revenue.sort(UserRevenue.total_amount.desc())
 print("Step 5-6: Aggregated and sorted by revenue")
 print()
 

--- a/examples/generic_functions.py
+++ b/examples/generic_functions.py
@@ -6,7 +6,7 @@ The type checker preserves the concrete schema through generic function calls.
 
 from __future__ import annotations
 
-from colnade import Column, DataFrame, Float64, Schema, UInt64, Utf8
+import colnade as cn
 from colnade.schema import S
 from colnade_polars import from_rows
 
@@ -15,16 +15,16 @@ from colnade_polars import from_rows
 # ---------------------------------------------------------------------------
 
 
-class Users(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    score: Column[Float64]
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    score: cn.Column[cn.Float64]
 
 
-class Products(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    price: Column[Float64]
+class Products(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    price: cn.Column[cn.Float64]
 
 
 # ---------------------------------------------------------------------------
@@ -32,7 +32,7 @@ class Products(Schema):
 # ---------------------------------------------------------------------------
 
 
-def first_n(df: DataFrame[S], n: int) -> DataFrame[S]:
+def first_n(df: cn.DataFrame[S], n: int) -> cn.DataFrame[S]:
     """Return the first n rows. Works with any schema.
 
     The type checker knows:
@@ -42,12 +42,12 @@ def first_n(df: DataFrame[S], n: int) -> DataFrame[S]:
     return df.head(n)
 
 
-def drop_null_rows(df: DataFrame[S]) -> DataFrame[S]:
+def drop_null_rows(df: cn.DataFrame[S]) -> cn.DataFrame[S]:
     """Drop all rows with any null values. Works with any schema."""
     return df.drop_nulls()
 
 
-def count_rows(df: DataFrame[S]) -> int:
+def count_rows(df: cn.DataFrame[S]) -> int:
     """Count rows in any typed DataFrame."""
     return len(df)
 

--- a/examples/joins.py
+++ b/examples/joins.py
@@ -5,7 +5,7 @@ Demonstrates how Colnade handles typed joins between two schemas.
 
 from __future__ import annotations
 
-from colnade import Column, Float64, Schema, UInt64, Utf8, mapped_from
+import colnade as cn
 from colnade_polars import from_rows
 
 # ---------------------------------------------------------------------------
@@ -13,23 +13,23 @@ from colnade_polars import from_rows
 # ---------------------------------------------------------------------------
 
 
-class Users(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    age: Column[UInt64]
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    age: cn.Column[cn.UInt64]
 
 
-class Orders(Schema):
-    id: Column[UInt64]
-    user_id: Column[UInt64]
-    amount: Column[Float64]
+class Orders(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    user_id: cn.Column[cn.UInt64]
+    amount: cn.Column[cn.Float64]
 
 
 # Output schema uses mapped_from to disambiguate joined columns
-class UserOrders(Schema):
-    user_name: Column[Utf8] = mapped_from(Users.name)
-    user_id: Column[UInt64] = mapped_from(Users.id)
-    amount: Column[Float64]
+class UserOrders(cn.Schema):
+    user_name: cn.Column[cn.Utf8] = cn.mapped_from(Users.name)
+    user_id: cn.Column[cn.UInt64] = cn.mapped_from(Users.id)
+    amount: cn.Column[cn.Float64]
 
 
 # ---------------------------------------------------------------------------

--- a/examples/nested_types.py
+++ b/examples/nested_types.py
@@ -5,7 +5,7 @@ Demonstrates typed access to struct fields and list operations.
 
 from __future__ import annotations
 
-from colnade import Column, Float64, List, Schema, Struct, UInt32, UInt64, Utf8
+import colnade as cn
 from colnade_polars import from_dict
 
 # ---------------------------------------------------------------------------
@@ -13,25 +13,25 @@ from colnade_polars import from_dict
 # ---------------------------------------------------------------------------
 
 
-class Address(Schema):
-    city: Column[Utf8]
-    zip_code: Column[Utf8]
+class Address(cn.Schema):
+    city: cn.Column[cn.Utf8]
+    zip_code: cn.Column[cn.Utf8]
 
 
-class UserProfile(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    address: Column[Struct[Address]]
-    tags: Column[List[Utf8]]
-    scores: Column[List[Float64]]
+class UserProfile(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    address: cn.Column[cn.Struct[Address]]
+    tags: cn.Column[cn.List[cn.Utf8]]
+    scores: cn.Column[cn.List[cn.Float64]]
 
 
 class ProfileWithCounts(UserProfile):
     """Extended schema with computed columns from list operations."""
 
-    tag_count: Column[UInt32]
-    first_tag: Column[Utf8]
-    total_score: Column[Float64]
+    tag_count: cn.Column[cn.UInt32]
+    first_tag: cn.Column[cn.Utf8]
+    total_score: cn.Column[cn.Float64]
 
 
 # ---------------------------------------------------------------------------

--- a/examples/null_handling.py
+++ b/examples/null_handling.py
@@ -5,7 +5,7 @@ Demonstrates how Colnade handles nullable data with type safety.
 
 from __future__ import annotations
 
-from colnade import Column, Float64, Schema, UInt64, Utf8
+import colnade as cn
 from colnade_polars import from_dict
 
 # ---------------------------------------------------------------------------
@@ -13,11 +13,11 @@ from colnade_polars import from_dict
 # ---------------------------------------------------------------------------
 
 
-class Users(Schema):
-    id: Column[UInt64]
-    name: Column[Utf8]
-    age: Column[UInt64 | None]
-    score: Column[Float64 | None]
+class Users(cn.Schema):
+    id: cn.Column[cn.UInt64]
+    name: cn.Column[cn.Utf8]
+    age: cn.Column[cn.UInt64 | None]
+    score: cn.Column[cn.Float64 | None]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Update all 6 `examples/*.py` to use `import colnade as cn` convention (matching tutorials)
- Fix `full_pipeline.py`: `score` column now correctly declared nullable (`Float64 | None`) since data contains `None` values
- Align tutorial/example class name: `ProfileWithStats` → `ProfileWithCounts` in nested-types tutorial
- Fix sort API in `full_pipeline.py`: `descending=True` → `.desc()` (matching tutorial style)
- Fix full-pipeline tutorial: `score` column now nullable
- Remove stale "eager only" comments for `head()`/`tail()` in dataframes.md (both available on LazyFrame since v0.5.3)

## Test plan
- [x] All 6 examples run successfully
- [x] All 7 pre-commit checks pass (1364 tests, ruff, ty, mkdocs, etc.)

Closes #170, closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)