### PR TITLE
Fix ty false positives on filter(), &/|, and Schema.Row() (#184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Type-checker false positives on `filter()`, `&`/`|`, and `Schema.Row(...)`** — `Column.__eq__` is now overloaded so `col == value` is typed as `BinOp[Bool]` (accepted by `filter()` and combinable with `&`/`|`) while `col == col` stays a `JoinCondition` for `.join(on=...)`. `Schema.Row(...)` now accepts keyword arguments under static checking instead of resolving to `object()`. Idiomatic Colnade code no longer needs `# ty: ignore` on these (#184)
+
 ## [0.8.1] - 2026-03-01
 
 ### Fixed

--- a/docs/user-guide/type-checking.md
+++ b/docs/user-guide/type-checking.md
@@ -138,13 +138,17 @@ UserProfile.tags.list.sum()   # NOT caught — tags is List[Utf8], sum makes no 
 
 This is a current limitation of Python type checkers — property-based self-narrowing (needed to restrict `.list` to `Column[List[...]]`) is not yet supported. The annotations are in place and will become precise when type checker support improves.
 
-### Cross-schema equality return type
+### Column-to-column equality is treated as a join key
 
-`Column.__eq__` returns `BinOp[Bool] | JoinCondition` (union type) because it produces a `JoinCondition` for cross-schema comparisons and `BinOp[Bool]` for same-schema comparisons. The `join()` method expects `JoinCondition`, so a `type: ignore[invalid-argument-type]` comment is needed:
+`Column.__eq__` is overloaded so that comparing two columns (`Users.id == Orders.user_id`) is typed as a `JoinCondition`, while comparing a column to a value (`Users.age == 30`) is typed as `BinOp[Bool]`. This means both the common cases type-check without suppressions:
 
 ```python
-users.join(orders, on=Users.id == Orders.user_id)  # type: ignore[invalid-argument-type]
+users.join(orders, on=Users.id == Orders.user_id)   # JoinCondition — accepted by join()
+df.filter(Users.age == 30)                            # BinOp[Bool] — accepted by filter()
+df.filter((Users.age == 30) & (Users.name == "Alice"))
 ```
+
+The one edge case: a *same-schema* column-to-column comparison (`Users.age == Users.score`) returns `BinOp[Bool]` at runtime but is statically typed as `JoinCondition`, so passing it to `filter()` is rejected by the type checker. This is rare; rewrite it as an explicit comparison or add a `type: ignore` at that call site if needed.
 
 ## Supported type checkers
 

--- a/src/colnade/schema.py
+++ b/src/colnade/schema.py
@@ -9,7 +9,7 @@ Defines the foundational layer that makes column references statically verifiabl
 from __future__ import annotations
 
 import typing
-from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, overload
 
 from colnade._types import DType, T
 
@@ -218,6 +218,18 @@ class Column(Generic[DType]):
     def __le__(self, other: Any) -> BinOp[Bool]:
         return self._binop(other, "<=")
 
+    # Overloads disambiguate the two roles of ``==`` for type checkers:
+    #   Column == Column  → JoinCondition  (a join key; see .join(on=...))
+    #   Column == value   → BinOp[Bool]    (a filter predicate)
+    # Without them, every ``==`` is typed as the union ``BinOp[Bool] |
+    # JoinCondition``, which makes ``filter(Schema.col == value)`` and
+    # ``&``/``|`` chaining fail to type-check (see issue #184). Statically,
+    # any column-to-column ``==`` is treated as a JoinCondition even though
+    # the runtime returns BinOp[Bool] for same-schema comparisons.
+    @overload
+    def __eq__(self, other: Column[Any]) -> JoinCondition: ...
+    @overload
+    def __eq__(self, other: object) -> BinOp[Bool]: ...
     def __eq__(self, other: Any) -> BinOp[Bool] | JoinCondition:  # type: ignore[override]
         if isinstance(other, Column) and self.schema is not other.schema:
             from colnade.expr import JoinCondition as _JoinCondition
@@ -607,6 +619,16 @@ class Row(Generic[S]):
 
         Users.Row(id=1, name="Alice", age=30)  # type is Row[Users]
     """
+
+    if TYPE_CHECKING:
+        # The per-schema Row dataclass is generated at runtime by
+        # ``_build_row_class`` (via ``make_dataclass``), so type checkers
+        # only ever see this base class. Without a constructor here, static
+        # checkers resolve ``Users.Row(name=..., age=...)`` to ``object()``
+        # and reject every keyword argument (see issue #184). Accepting
+        # ``**fields`` keeps keyword construction type-checking; per-field
+        # value types are still validated at runtime by the dataclass.
+        def __init__(self, **fields: Any) -> None: ...
 
 
 def _build_row_class(schema_name: str, schema_cls: type, columns: dict[str, Column[Any]]) -> type:

--- a/tests/typing/test_dataframe.py
+++ b/tests/typing/test_dataframe.py
@@ -50,6 +50,22 @@ def check_filter_preserves_schema(df: DataFrame[Users]) -> DataFrame[Users]:
     return df.filter(Users.age > 18)
 
 
+def check_filter_equality_predicate(df: DataFrame[Users]) -> DataFrame[Users]:
+    # ``col == value`` must type-check as a filter predicate (issue #184 A).
+    # Without overloaded ``Column.__eq__`` it is ``BinOp[Bool] | JoinCondition``
+    # and ``filter`` (which expects ``Expr[Bool]``) rejects the union.
+    return df.filter(Users.age == 30)
+
+
+def check_filter_combined_predicate(df: DataFrame[Users]) -> DataFrame[Users]:
+    # ``&``/``|`` over equality predicates must type-check (issue #184 B).
+    return df.filter((Users.age == 30) & (Users.name == "Alice"))
+
+
+def check_filter_or_predicate(df: DataFrame[Users]) -> DataFrame[Users]:
+    return df.filter((Users.age == 30) | (Users.age == 40))
+
+
 def check_sort_preserves_schema(df: DataFrame[Users]) -> DataFrame[Users]:
     return df.sort(Users.name)
 

--- a/tests/typing/test_join.py
+++ b/tests/typing/test_join.py
@@ -43,6 +43,19 @@ class Orders(Schema):
 # --- Join return types ---
 
 
+def check_cross_schema_eq_is_join_condition() -> None:
+    # ``Column == Column`` must be typed as a JoinCondition so it can be passed
+    # straight to ``.join(on=...)`` (issue #184 — the overloaded ``__eq__``).
+    cond: JoinCondition = Users.id == Orders.user_id
+    _ = cond
+
+
+def check_join_with_inline_condition(
+    df: DataFrame[Users], orders: DataFrame[Orders]
+) -> JoinedDataFrame[Users, Orders]:
+    return df.join(orders, on=Users.id == Orders.user_id)
+
+
 def check_dataframe_join(
     df: DataFrame[Users], orders: DataFrame[Orders], cond: JoinCondition
 ) -> JoinedDataFrame[Users, Orders]:

--- a/tests/typing/test_schema.py
+++ b/tests/typing/test_schema.py
@@ -8,7 +8,7 @@ With the Column[DType] annotation pattern, type checkers see schema
 attributes as Column instances with full access to expression methods.
 """
 
-from colnade import Column, Datetime, Float64, Schema, UInt8, UInt64, Utf8
+from colnade import Column, Datetime, Float64, Row, Schema, UInt8, UInt64, Utf8
 
 # --- Schema definition compiles cleanly ---
 
@@ -63,3 +63,13 @@ def check_schema_typevars() -> None:
     _ = S
     _ = S2
     _ = S3
+
+
+# --- Row keyword construction type-checks (issue #184 C) ---
+
+
+def check_row_kwargs_construction() -> None:
+    # Auto-generated ``Schema.Row`` must accept keyword arguments without the
+    # type checker rejecting them as unknown parameters of ``object``.
+    row = Users.Row(id=1, name="Alice", age=30, score=9.5)
+    _: Row[Users] = row


### PR DESCRIPTION
Fixes #184.

## Problem

Three type-checker false positives forced `# ty: ignore` onto exactly the operations Colnade is meant to make safe. All reproduced against `main` (Python 3.14.6, ty 0.0.54) — the script ran cleanly but `ty check` reported 4 diagnostics:

- **A.** `df.filter(Users.age == 30)` — rejected. `Column.__eq__` returned the union `BinOp[Bool] | JoinCondition` from a single signature, and `filter()` only accepts `Expr[Bool]`.
- **B.** `(Users.age == 30) & (Users.name == "Alice")` — `&` unsupported, because the operands were typed as that same union.
- **C.** `Users.Row(name="Alice", age=30)` — keyword args rejected; `Schema.Row` resolved to `object()` statically because the per-schema dataclass is generated at runtime.

## Fix

- **A/B** — Overload `Column.__eq__`: `col == col → JoinCondition` (a join key, for `.join(on=...)`), `col == value → BinOp[Bool]` (a filter predicate, accepted by `filter()` and combinable with `&`/`|`). Runtime implementation is unchanged, so existing `JoinCondition`/`BinOp` dispatch unit tests still pass.
- **C** — Give the base `Row` a `TYPE_CHECKING`-only keyword constructor (`def __init__(self, **fields: Any)`) so kwargs type-check. Per-field value types are still validated at runtime by the generated dataclass.

### Known edge case
A *same-schema* column-to-column comparison (`Users.age == Users.score`) returns `BinOp[Bool]` at runtime but is now statically typed `JoinCondition`, so passing it directly to `filter()` is rejected. This is rare and documented in the type-checking guide. The common cases (value comparisons in `filter`, cross-schema `==` in `join`) all type-check cleanly.

## Verification

- Issue's repro is now **clean under ty, mypy, and pyright**.
- Core safety intact: column-name typos (`Users.naem`) and string-column `.sum()` are still flagged.
- Full pre-commit suite passes: ruff check/format, `pytest` (1364 passed), `ty check tests/typing/ --error-on-warning`, API-docs, changelog, and `mkdocs build --strict`.

## Changes
- `src/colnade/schema.py` — overloaded `__eq__`; `Row` keyword constructor.
- `tests/typing/{test_dataframe,test_join,test_schema}.py` — regression tests for A/B/C and inline join-condition.
- `docs/user-guide/type-checking.md` — replace the stale "needs `type: ignore`" note with current behavior + the edge case.
- `CHANGELOG.md` — `Fixed` entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)